### PR TITLE
[CCCP-79-feature/inspect-txpool-before-relay]

### DIFF
--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -157,6 +157,8 @@ pub struct EventMessage {
 	pub tx_request: TransactionRequest,
 	/// Additional data of the transaction request.
 	pub metadata: EventMetadata,
+	/// Check mempool to prevent duplicate relay
+	pub check_mempool: bool,
 }
 
 impl EventMessage {
@@ -165,8 +167,9 @@ impl EventMessage {
 		retries_remaining: u8,
 		tx_request: TransactionRequest,
 		metadata: EventMetadata,
+		check_mempool: bool,
 	) -> Self {
-		Self { retries_remaining, tx_request, metadata }
+		Self { retries_remaining, tx_request, metadata, check_mempool }
 	}
 }
 

--- a/client/src/eth/handlers/bridge_relay_handler.rs
+++ b/client/src/eth/handlers/bridge_relay_handler.rs
@@ -364,6 +364,7 @@ impl<T: JsonRpcClient> BridgeRelayHandler<T> {
 					DEFAULT_RETRIES,
 					tx_request,
 					EventMetadata::BridgeRelay(metadata.clone()),
+					true,
 				))
 				.unwrap();
 			log::info!(

--- a/client/src/eth/handlers/roundup_relay_handler.rs
+++ b/client/src/eth/handlers/roundup_relay_handler.rs
@@ -251,6 +251,7 @@ impl<T: JsonRpcClient> RoundupRelayHandler<T> {
 							roundup_submit.round,
 							target_chain.event_sender.id,
 						)),
+						true,
 					))
 					.unwrap();
 			}

--- a/periodic/src/heartbeat_sender.rs
+++ b/periodic/src/heartbeat_sender.rs
@@ -106,6 +106,7 @@ impl<T: JsonRpcClient> HeartbeatSender<T> {
 			DEFAULT_RETRIES,
 			tx_request,
 			EventMetadata::Heartbeat(metadata.clone()),
+			false,
 		)) {
 			Ok(()) => log::info!(
 				target: &self.client.get_chain_name(),

--- a/periodic/src/price_feeder.rs
+++ b/periodic/src/price_feeder.rs
@@ -128,6 +128,7 @@ impl<T: JsonRpcClient> OraclePriceFeeder<T> {
 			DEFAULT_RETRIES,
 			tx_request,
 			EventMetadata::PriceFeed(metadata.clone()),
+			false,
 		)) {
 			Ok(()) => log::info!(
 				target: &self.client.get_chain_name(),

--- a/periodic/src/roundup_emitter.rs
+++ b/periodic/src/roundup_emitter.rs
@@ -143,6 +143,7 @@ impl<T: JsonRpcClient> RoundupEmitter<T> {
 			DEFAULT_RETRIES,
 			tx_request,
 			EventMetadata::VSPPhase1(metadata.clone()),
+			false,
 		)) {
 			Ok(()) => log::info!(
 				target: format!("{}::VSP-Phase1", &self.client.get_chain_name()).as_str(),


### PR DESCRIPTION
## Description

이벤트 릴레이의 중복 제출 방지를 위해 트랜잭션 전송 직전 txpool(mempool)을 조회하는 단계를 추가했습니다.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
