### PR TITLE
hotfix: Fix to check only external chains' mempool

### DIFF
--- a/client/src/eth/tx.rs
+++ b/client/src/eth/tx.rs
@@ -224,15 +224,15 @@ impl<T: 'static + JsonRpcClient> TransactionManager<T> {
 		tx_request: &TransactionRequest,
 		check_mempool: bool,
 	) -> bool {
-		if !check_mempool {
+		if (!check_mempool) || self.client.is_native {
 			return false
 		}
 
 		let data = tx_request.data.as_ref().unwrap();
 		let to = tx_request.to.as_ref().unwrap().as_address().unwrap();
 
-		let txpool_pending_contents = self.client.provider.txpool_content().await.unwrap().pending;
-		for (_address, tx_map) in txpool_pending_contents.iter() {
+		let mempool_pending_contents = self.client.provider.txpool_content().await.unwrap().pending;
+		for (_address, tx_map) in mempool_pending_contents.iter() {
 			for (_nonce, transaction) in tx_map.iter() {
 				if transaction.to.unwrap_or_default() == *to && transaction.input == *data {
 					return true


### PR DESCRIPTION
## Description

중복 릴레이 방지를 위해 멤풀 체킹하는건 외부 체인에서만 동작하도록 수정되었습니다.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
