### PR TITLE
CCCP-120, fix: escalate estimated gas

### DIFF
--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -13,6 +13,9 @@ pub const DEFAULT_RETRY_INTERVAL_MS: u64 = 3000;
 /// The coefficient that will be multiplied to the retry interval on every new retry.
 pub const RETRY_COEFFICIENT: u64 = 2;
 
+/// The coefficient that will be multiplied to the estimated gas.
+pub const GAS_COEFFICIENT: f64 = 1.5;
+
 #[derive(Clone, Debug)]
 pub struct BridgeRelayMetadata {
 	/// The bridge direction.


### PR DESCRIPTION
## Description

### Hotfix
- 동일 블록에 포함되는 연속적인 relay 트랜잭션으로 인해, 증가되는 gas를 대비할 수 있도록 estimated gas에 고정 상수값만큼 곱하여 사용하도록 수정

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
