### PR TITLE
chore: capture message instead of error

### DIFF
--- a/client/src/eth/handlers/bridge_relay_handler.rs
+++ b/client/src/eth/handlers/bridge_relay_handler.rs
@@ -446,7 +446,18 @@ impl<T: JsonRpcClient> BridgeRelayHandler<T> {
 								receipt.block_number.unwrap(),
 								receipt.transaction_hash,
 							);
-							sentry::capture_error(&error);
+							sentry::capture_message(
+								format!(
+									"[{}]-[{}] ⚠️  Tried to re-process the reverted relay transaction but failed to decode function input: {}, Reverted at: {:?}-{:?}",
+									&self.client.get_chain_name(),
+									SUB_LOG_TARGET,
+									error.to_string(),
+									receipt.block_number.unwrap(),
+									receipt.transaction_hash,
+								)
+								.as_str(),
+								sentry::Level::Warning,
+							);
 						},
 					}
 				}
@@ -601,7 +612,18 @@ impl<T: JsonRpcClient> BridgeRelayHandler<T> {
 						metadata,
 						error.to_string()
 					);
-					sentry::capture_error(&error);
+					sentry::capture_message(
+						format!(
+							"[{}]-[{}] ❗️ Failed to send relay transaction to chain({:?}): {}, Error: {}",
+							&self.client.get_chain_name(),
+							SUB_LOG_TARGET,
+							chain_id,
+							metadata,
+							error
+						)
+						.as_str(),
+						sentry::Level::Error,
+					);
 				},
 			}
 		}

--- a/client/src/eth/handlers/roundup_relay_handler.rs
+++ b/client/src/eth/handlers/roundup_relay_handler.rs
@@ -132,7 +132,17 @@ impl<T: JsonRpcClient> Handler for RoundupRelayHandler<T> {
 						receipt.transaction_hash,
 						e.to_string(),
 					);
-					sentry::capture_error(&e);
+					sentry::capture_message(
+						format!(
+							"[{}]-[{}] Error on decoding RoundUp event ({:?}):{}",
+							&self.client.get_chain_name(),
+							SUB_LOG_TARGET,
+							receipt.transaction_hash,
+							e
+						)
+						.as_str(),
+						sentry::Level::Error,
+					);
 					continue
 				},
 			}

--- a/client/src/eth/tx.rs
+++ b/client/src/eth/tx.rs
@@ -443,7 +443,18 @@ impl<T: 'static + JsonRpcClient> OnFailHandler for TransactionManager<T> {
 			msg.retries_remaining - 1,
 			error.to_string(),
 		);
-		sentry::capture_error(&error);
+		sentry::capture_message(
+			format!(
+				"[{}]-[{}] ♻️  Unknown error while requesting a transaction request: {}, Retries left: {:?}, Error: {}",
+				&self.client.get_chain_name(),
+				SUB_LOG_TARGET,
+				msg.metadata,
+				msg.retries_remaining - 1,
+				error
+			)
+			.as_str(),
+			sentry::Level::Error,
+		);
 		self.retry_transaction(msg).await;
 	}
 

--- a/periodic/src/price_feeder.rs
+++ b/periodic/src/price_feeder.rs
@@ -153,7 +153,18 @@ impl<T: JsonRpcClient> OraclePriceFeeder<T> {
 					metadata,
 					error.to_string()
 				);
-				sentry::capture_error(&error);
+				sentry::capture_message(
+					format!(
+						"[{}]-[{}] ❗️ Failed to request price feed transaction to chain({:?}): {}, Error: {}",
+						&self.client.get_chain_name(),
+						SUB_LOG_TARGET,
+						self.config.chain_id,
+						metadata,
+						error
+					)
+					.as_str(),
+					sentry::Level::Error,
+				);
 			},
 		}
 	}


### PR DESCRIPTION
## Description

### Changes
- 조금 더 구체적인 sentry 로그 확인을 위해 capture_error 대신에 capture_message를 사용하도록 변경

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
