### PR TITLE
CCCP-200, chore: Move Periodic schedules to primitive constants.

### DIFF
--- a/configs/config.mainnet.yaml
+++ b/configs/config.mainnet.yaml
@@ -54,11 +54,6 @@ handler_configs:
   - handler_type: Roundup
     watch_list: [3068]
 
-periodic_configs:
-  oracle_price_feeder: "0 */5 * * * * *" # Every 5th minute.
-  roundup_emitter: "*/15 * * * * * *" # Every 15th seconds.
-  heartbeat: "0 * * * * * *" # Every minute.
-
 ###  The items below are optional. ###
 
 bootstrap_config:

--- a/configs/config.testnet.yaml
+++ b/configs/config.testnet.yaml
@@ -55,11 +55,6 @@ handler_configs:
   - handler_type: Roundup
     watch_list: [49088]
 
-periodic_configs:
-  oracle_price_feeder: "0 */5 * * * * *" # Every 5th minute.
-  roundup_emitter: "*/15 * * * * * *" # Every 15th seconds.
-  heartbeat: "0 * * * * * *" # Every minute.
-
 ###  The items below are optional. ###
 
 bootstrap_config:

--- a/periodic/src/heartbeat_sender.rs
+++ b/periodic/src/heartbeat_sender.rs
@@ -4,7 +4,7 @@ use br_client::eth::{
 use br_primitives::{
 	errors::{INVALID_BIFROST_NATIVENESS, INVALID_PERIODIC_SCHEDULE},
 	eth::GasCoefficient,
-	sub_display_format, PeriodicWorker,
+	sub_display_format, PeriodicWorker, HEARTBEAT_SCHEDULE,
 };
 use cron::Schedule;
 use ethers::{providers::JsonRpcClient, types::TransactionRequest};
@@ -73,13 +73,9 @@ impl<T: JsonRpcClient> PeriodicWorker for HeartbeatSender<T> {
 
 impl<T: JsonRpcClient> HeartbeatSender<T> {
 	/// Instantiates a new `HeartbeatSender` instance.
-	pub fn new(
-		schedule: String,
-		client: Arc<EthClient<T>>,
-		event_senders: Vec<Arc<EventSender>>,
-	) -> Self {
+	pub fn new(client: Arc<EthClient<T>>, event_senders: Vec<Arc<EventSender>>) -> Self {
 		Self {
-			schedule: Schedule::from_str(&schedule).expect(INVALID_PERIODIC_SCHEDULE),
+			schedule: Schedule::from_str(HEARTBEAT_SCHEDULE).expect(INVALID_PERIODIC_SCHEDULE),
 			event_sender: event_senders
 				.iter()
 				.find(|channel| channel.is_native)

--- a/periodic/src/roundup_emitter.rs
+++ b/periodic/src/roundup_emitter.rs
@@ -20,6 +20,7 @@ use br_primitives::{
 	eth::{BootstrapState, GasCoefficient, RoundUpEventStatus, BOOTSTRAP_BLOCK_CHUNK_SIZE},
 	socket::{RoundUpSubmit, SerializedRoundUp, Signatures, SocketContractEvents},
 	sub_display_format, PeriodicWorker, INVALID_BIFROST_NATIVENESS, INVALID_CONTRACT_ABI,
+	ROUNDUP_EMITTER_SCHEDULE,
 };
 
 const SUB_LOG_TARGET: &str = "roundup-emitter";
@@ -94,7 +95,6 @@ impl<T: JsonRpcClient> RoundupEmitter<T> {
 	pub fn new(
 		event_senders: Vec<Arc<EventSender>>,
 		clients: Vec<Arc<EthClient<T>>>,
-		schedule: String,
 		bootstrap_states: Arc<RwLock<Vec<BootstrapState>>>,
 		bootstrap_config: Option<BootstrapConfig>,
 	) -> Self {
@@ -112,7 +112,8 @@ impl<T: JsonRpcClient> RoundupEmitter<T> {
 				.find(|event_sender| event_sender.is_native)
 				.expect(INVALID_BIFROST_NATIVENESS)
 				.clone(),
-			schedule: Schedule::from_str(&schedule).expect(INVALID_PERIODIC_SCHEDULE),
+			schedule: Schedule::from_str(ROUNDUP_EMITTER_SCHEDULE)
+				.expect(INVALID_PERIODIC_SCHEDULE),
 			bootstrap_states,
 			bootstrap_config,
 		}

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -51,8 +51,6 @@ pub struct RelayerConfig {
 	pub evm_providers: Vec<EVMProvider>,
 	/// Handler configs
 	pub handler_configs: Vec<HandlerConfig>,
-	/// Periodic worker configs
-	pub periodic_configs: Option<PeriodicWorkerConfig>,
 	/// Bootstrapping configs
 	pub bootstrap_config: Option<BootstrapConfig>,
 	/// Sentry config
@@ -138,16 +136,6 @@ pub struct HandlerConfig {
 	pub handler_type: HandlerType,
 	/// Watch target list
 	pub watch_list: Vec<ChainID>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub struct PeriodicWorkerConfig {
-	/// Oracle price feeder
-	pub oracle_price_feeder: String,
-	/// Roundup Phase1 feeder
-	pub roundup_emitter: String,
-	/// Heartbeat sender
-	pub heartbeat: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]

--- a/primitives/src/periodic.rs
+++ b/primitives/src/periodic.rs
@@ -6,6 +6,10 @@ use ethers::types::U256;
 use serde::Deserialize;
 use tokio::time::sleep;
 
+pub const HEARTBEAT_SCHEDULE: &str = "0 */5 * * * * *"; // Every 5th minute.
+pub const PRICE_FEEDER_SCHEDULE: &str = "*/15 * * * * * *"; // Every 15th second.
+pub const ROUNDUP_EMITTER_SCHEDULE: &str = "0 * * * * * *"; // Every minute.
+
 #[async_trait]
 pub trait PeriodicWorker {
 	fn schedule(&self) -> Schedule;


### PR DESCRIPTION
## Description

* Periodic 스케줄 설정을 primitives 내 상수로 정의하는 것으로 바뀝니다.
* 트랜잭션의 전파, 밸리데이터가 일하는 시간 등 고려하여 최소한 스케줄 30초 전에 price feed 트랜잭션을 전송하도록 수정되었습니다.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
