### PR TITLE
CCCP-212, fix: txpool namespace verification

### DIFF
--- a/client/src/eth/tx/eip1559_manager.rs
+++ b/client/src/eth/tx/eip1559_manager.rs
@@ -161,7 +161,7 @@ impl<T: 'static + JsonRpcClient> TransactionManager<T> for Eip1559TransactionMan
 	}
 
 	async fn initialize(&mut self) {
-		self.is_txpool_enabled = self.client.provider.txpool_status().await.is_ok();
+		self.is_txpool_enabled = self.client.provider.txpool_content().await.is_ok();
 
 		self.flush_stuck_transaction().await;
 	}

--- a/client/src/eth/tx/legacy_manager.rs
+++ b/client/src/eth/tx/legacy_manager.rs
@@ -196,7 +196,7 @@ impl<T: 'static + JsonRpcClient> TransactionManager<T> for LegacyTransactionMana
 	}
 
 	async fn initialize(&mut self) {
-		self.is_txpool_enabled = self.client.provider.txpool_status().await.is_ok();
+		self.is_txpool_enabled = self.client.provider.txpool_content().await.is_ok();
 
 		self.flush_stuck_transaction().await;
 	}


### PR DESCRIPTION
## Description

txpool namespace의 활성화 여부를 판단하기 위해 `txpool_status`를 사용해 왔으나, 특정 네트워크에서 정책상 `txpool_content`만을 비활성화하는 경우가 있음.
실제로 사용해야 하는건 `txpool_content`이므로 활성화 여부도 `txpool_content`를 사용하여 확인하도록 변경

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
