### PR TITLE
test: now sonarqube workflow use runner group from org settings

### DIFF
--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -6,7 +6,8 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: self-hosted
+    runs-on: 
+      group: ec2-runner-group
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
## Description
정적분석기인 SonarQube를 테스트하기 위한 workflow를 추가하였습니다
Public repo에서는 self-hosted runner를 직접 사용할 수 없으므로, runner 그룹을 새로 만들고 이를 사용하는 yaml로 변경합니다. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
