### PR TITLE
[CCCP-224] error on switching legacy <-> eip1559 tx_handler

### DIFF
--- a/client/src/eth/tx/legacy_manager.rs
+++ b/client/src/eth/tx/legacy_manager.rs
@@ -91,7 +91,7 @@ impl<T: 'static + JsonRpcClient> LegacyTransactionManager<T> {
 				is_txpool_enabled: false,
 				is_initially_escalated,
 				gas_price_coefficient,
-				min_gas_price: U256::from(min_gas_price.unwrap_or(0) * 1_000_000_000),
+				min_gas_price: U256::from(min_gas_price.unwrap_or(0)),
 				debug_mode,
 				duplicate_confirm_delay,
 			},

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -85,6 +85,8 @@ pub struct EVMProvider {
 	pub is_relay_target: bool,
 	/// If true, enables Eip1559. (default: false)
 	pub eip1559: Option<bool>,
+	/// The minimum value use for gas_price. (default: 0, unit: GWEI)
+	pub min_gas_price: Option<u64>,
 	/// The minimum priority fee required. (default: 0)
 	pub min_priority_fee: Option<u64>,
 	/// Gas price escalate interval(seconds) when tx stuck in mempool. (default: 12)

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -85,7 +85,7 @@ pub struct EVMProvider {
 	pub is_relay_target: bool,
 	/// If true, enables Eip1559. (default: false)
 	pub eip1559: Option<bool>,
-	/// The minimum value use for gas_price. (default: 0, unit: GWEI)
+	/// The minimum value use for gas_price. (default: 0, unit: WEI)
 	pub min_gas_price: Option<u64>,
 	/// The minimum priority fee required. (default: 0)
 	pub min_priority_fee: Option<u64>,

--- a/primitives/src/errors.rs
+++ b/primitives/src/errors.rs
@@ -27,3 +27,6 @@ pub const INVALID_CONFIG_FILE_STRUCTURE: &str =
 
 pub const INVALID_CHAIN_SPECIFICATION: &str =
 	"Invalid --chain specification provided. Please check your CLI options.";
+
+pub const NETWORK_NOT_SUPPORT_EIP1559: &str =
+	"Network not support EIP-1559 transaction. Please check your evm_providers config";

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -103,6 +103,7 @@ pub fn new_relay_base(config: Configuration) -> Result<RelayBase, ServiceError> 
 							system.debug_mode.unwrap_or(false),
 							evm_provider.escalate_interval,
 							evm_provider.escalate_percentage,
+							evm_provider.min_gas_price,
 							evm_provider.is_initially_escalated.unwrap_or(false),
 							evm_provider.duplicate_confirm_delay,
 						);


### PR DESCRIPTION
## Description

이미 legacy tx handler로 설정되어 실행된 릴레이어가 eip1559 tx handler로 전환될때(역의 경우 포함하여), 종료 전 전송한 트랜잭션이 txpool에 아직 머무르고 있을 시 에러가 발생하던 문제의 수정입니다.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
