### PR TITLE
CCCP-263, fix: reduce maximum bootstrap offset

### DIFF
--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -47,8 +47,8 @@ pub const MAX_DUPLICATE_CONFIRM_DELAY_MS: u64 = 60_000;
 /// The minimum batch size allowed for `eth_getLogs()`. (=1 block)
 pub const MIN_GET_LOGS_BATCH_SIZE: u64 = 1;
 
-/// The maximum round offset allowed for bootstrap. (=64 rounds)
-pub const MAX_BOOTSTRAP_ROUND_OFFSET: u32 = 64;
+/// The maximum round offset allowed for bootstrap. (=14 rounds)
+pub const MAX_BOOTSTRAP_ROUND_OFFSET: u32 = 14;
 
 /// Error type for the CLI.
 #[derive(Debug, thiserror::Error)]


### PR DESCRIPTION
## Description

- 설정 가능한 최대 부트스트랩 라운드 오프셋 감소 (64 -> 14)

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
