### PR TITLE
Feature: Implement `SocketRollbackHandler` and `ExecutionFilter`

### DIFF
--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -10,7 +10,7 @@ use ethers::types::{
 use tokio::sync::mpsc::{error::SendError, UnboundedSender};
 
 use br_primitives::{
-	eth::{ChainID, GasCoefficient, SocketEventStatus},
+	eth::{ChainID, GasCoefficient, SocketEventStatus, SocketVariants},
 	PriceResponse,
 };
 
@@ -48,6 +48,8 @@ pub struct SocketRelayMetadata {
 	pub receiver: Address,
 	/// The flag whether this relay is processed on bootstrap.
 	pub is_bootstrap: bool,
+	/// The variants this request contains.
+	pub variants: SocketVariants,
 }
 
 impl SocketRelayMetadata {
@@ -60,7 +62,16 @@ impl SocketRelayMetadata {
 		receiver: Address,
 		is_bootstrap: bool,
 	) -> Self {
-		Self { is_inbound, status, sequence, src_chain_id, dst_chain_id, receiver, is_bootstrap }
+		Self {
+			is_inbound,
+			status,
+			sequence,
+			src_chain_id,
+			dst_chain_id,
+			receiver,
+			is_bootstrap,
+			variants: SocketVariants::default(),
+		}
 	}
 }
 

--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -187,6 +187,46 @@ impl Display for FlushMetadata {
 }
 
 #[derive(Clone, Debug)]
+pub struct RollbackMetadata {
+	/// The socket relay direction flag.
+	pub is_inbound: bool,
+	/// The socket event status.
+	pub status: SocketEventStatus,
+	/// The socket request sequence ID.
+	pub sequence: u128,
+	/// The source chain ID.
+	pub src_chain_id: ChainID,
+	/// The destination chain ID.
+	pub dst_chain_id: ChainID,
+}
+
+impl RollbackMetadata {
+	pub fn new(
+		is_inbound: bool,
+		status: SocketEventStatus,
+		sequence: u128,
+		src_chain_id: ChainID,
+		dst_chain_id: ChainID,
+	) -> Self {
+		Self { is_inbound, status, sequence, src_chain_id, dst_chain_id }
+	}
+}
+
+impl Display for RollbackMetadata {
+	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+		write!(
+			f,
+			"Relay({}-{:?}-{:?}, {:?} -> {:?})",
+			if self.is_inbound { "Inbound".to_string() } else { "Outbound".to_string() },
+			self.status,
+			self.sequence,
+			self.src_chain_id,
+			self.dst_chain_id,
+		)
+	}
+}
+
+#[derive(Clone, Debug)]
 pub enum EventMetadata {
 	SocketRelay(SocketRelayMetadata),
 	PriceFeed(PriceFeedMetadata),
@@ -194,6 +234,7 @@ pub enum EventMetadata {
 	VSPPhase2(VSPPhase2Metadata),
 	Heartbeat(HeartbeatMetadata),
 	Flush(FlushMetadata),
+	Rollback(RollbackMetadata),
 }
 
 impl Display for EventMetadata {
@@ -208,6 +249,7 @@ impl Display for EventMetadata {
 				EventMetadata::VSPPhase2(metadata) => metadata.to_string(),
 				EventMetadata::Heartbeat(metadata) => metadata.to_string(),
 				EventMetadata::Flush(metadata) => metadata.to_string(),
+				EventMetadata::Rollback(metadata) => metadata.to_string(),
 			}
 		)
 	}

--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -227,7 +227,7 @@ impl Display for RollbackMetadata {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(
 			f,
-			"Relay({}-{:?}-{:?}, {:?} -> {:?})",
+			"Rollback({}-{:?}-{:?}, {:?} -> {:?})",
 			if self.is_inbound { "Inbound".to_string() } else { "Outbound".to_string() },
 			self.status,
 			self.sequence,

--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -79,12 +79,13 @@ impl Display for SocketRelayMetadata {
 	fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
 		write!(
 			f,
-			"Relay({}-{:?}-{:?}, {:?} -> {:?})",
+			"Relay({}-{:?}-{:?}, {:?} -> {:?}, {:?})",
 			if self.is_inbound { "Inbound".to_string() } else { "Outbound".to_string() },
 			self.status,
 			self.sequence,
 			self.src_chain_id,
 			self.dst_chain_id,
+			self.variants.version
 		)
 	}
 }
@@ -316,6 +317,42 @@ impl TxRequest {
 			TxRequest::Eip1559(tx_request) => {
 				TxRequest::Eip1559(tx_request.clone().gas(estimated_gas))
 			},
+		}
+	}
+
+	/// Sets the `max_fee_per_gas` field in the transaction request.
+	/// This method will only have effect when the type is EIP-1559.
+	/// It will be ignored if the type is legacy.
+	pub fn max_fee_per_gas(&self, max_fee_per_gas: U256) -> Self {
+		match self {
+			TxRequest::Legacy(tx_request) => TxRequest::Legacy(tx_request.clone()),
+			TxRequest::Eip1559(tx_request) => {
+				TxRequest::Eip1559(tx_request.clone().max_fee_per_gas(max_fee_per_gas))
+			},
+		}
+	}
+
+	/// Sets the `max_priority_fee_per_gas` field in the transaction request.
+	/// This method will only have effect when the type is EIP-1559.
+	/// It will be ignored if the type is legacy.
+	pub fn max_priority_fee_per_gas(&self, max_priority_fee_per_gas: U256) -> Self {
+		match self {
+			TxRequest::Legacy(tx_request) => TxRequest::Legacy(tx_request.clone()),
+			TxRequest::Eip1559(tx_request) => TxRequest::Eip1559(
+				tx_request.clone().max_priority_fee_per_gas(max_priority_fee_per_gas),
+			),
+		}
+	}
+
+	/// Sets the `gas_price` field in the transaction request.
+	/// This method will only have effect when the type is legacy.
+	/// It will be ignored if the type is EIP-1559.
+	pub fn gas_price(&self, gas_price: U256) -> Self {
+		match self {
+			TxRequest::Legacy(tx_request) => {
+				TxRequest::Legacy(tx_request.clone().gas_price(gas_price))
+			},
+			TxRequest::Eip1559(tx_request) => TxRequest::Eip1559(tx_request.clone()),
 		}
 	}
 

--- a/client/src/eth/handlers/execution_filter.rs
+++ b/client/src/eth/handlers/execution_filter.rs
@@ -18,9 +18,9 @@ const SUB_LOG_TARGET: &str = "execution-filter";
 /// The gas estimation result of the general message.
 enum EstimationResult {
 	/// The general message is executable. This contains the estimated gas amount.
-	Executable(U256),
+	Success(U256),
 	/// The general message is non-executable. This contains the error message.
-	NonExecutable(String),
+	Revert(String),
 }
 
 /// The task that tries to pre-gasEstimate the general message.

--- a/client/src/eth/handlers/execution_filter.rs
+++ b/client/src/eth/handlers/execution_filter.rs
@@ -53,7 +53,7 @@ impl<T: JsonRpcClient> ExecutionFilter<T> {
 		give_random_delay: bool,
 		gas_coefficient: GasCoefficient,
 	) {
-		if let Some(executor_adddress) = self.client.protocol_contracts.executor_address {
+		if let Some(executor_address) = self.client.protocol_contracts.executor_address {
 			log::info!(
 				target: &self.client.get_chain_name(),
 				"-[{}] ⛓️  Start Execution::Filter: {}",

--- a/client/src/eth/handlers/execution_filter.rs
+++ b/client/src/eth/handlers/execution_filter.rs
@@ -7,8 +7,8 @@ use std::{sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 use crate::eth::{
-	EthClient, EventMessage, EventMetadata, EventSender, SocketRelayMetadata, TxRequest,
-	DEFAULT_CALL_RETRIES, DEFAULT_CALL_RETRY_INTERVAL_MS,
+	EthClient, EventMessage, EventMetadata, EventSender, LegacyGasMiddleware, SocketRelayMetadata,
+	TxRequest, DEFAULT_CALL_RETRIES, DEFAULT_CALL_RETRY_INTERVAL_MS,
 };
 
 use super::SocketRelayBuilder;
@@ -65,7 +65,8 @@ impl<T: JsonRpcClient> ExecutionFilter<T> {
 				TransactionRequest::default()
 					.data(self.metadata.variants.clone().data)
 					.to(self.metadata.variants.receiver)
-					.from(executor_adddress),
+					.from(executor_adddress)
+					.gas_price(self.client.get_gas_price().await),
 			);
 
 			let estimated_gas = match self.try_gas_estimation(general_msg).await {

--- a/client/src/eth/handlers/execution_filter.rs
+++ b/client/src/eth/handlers/execution_filter.rs
@@ -63,7 +63,7 @@ impl<T: JsonRpcClient> ExecutionFilter<T> {
 
 			let general_msg = TxRequest::Legacy(
 				TransactionRequest::default()
-					.data(self.metadata.variants.clone().data)
+					.data(self.metadata.variants.data.clone())
 					.to(self.metadata.variants.receiver)
 					.from(executor_adddress)
 					.gas_price(self.client.get_gas_price().await),

--- a/client/src/eth/handlers/execution_filter.rs
+++ b/client/src/eth/handlers/execution_filter.rs
@@ -56,7 +56,7 @@ impl<T: JsonRpcClient> ExecutionFilter<T> {
 		if let Some(executor_adddress) = self.client.protocol_contracts.executor_address {
 			log::info!(
 				target: &self.client.get_chain_name(),
-				"-[{}] ⛓️ Start Execution::Filter: {}",
+				"-[{}] ⛓️  Start Execution::Filter: {}",
 				sub_display_format(SUB_LOG_TARGET),
 				self.metadata
 			);
@@ -73,7 +73,7 @@ impl<T: JsonRpcClient> ExecutionFilter<T> {
 				EstimationResult::NonExecutable(error) => {
 					log::warn!(
 						target: &self.client.get_chain_name(),
-						"-[{}] ⛓️ Execution::Filter Result → ❗️ Failure::Error({}): {}",
+						"-[{}] ⛓️  Execution::Filter Result → ❗️ Failure::Error({}): {}",
 						sub_display_format(SUB_LOG_TARGET),
 						error,
 						self.metadata
@@ -84,7 +84,7 @@ impl<T: JsonRpcClient> ExecutionFilter<T> {
 
 			log::info!(
 				target: &self.client.get_chain_name(),
-				"-[{}] ⛓️ Execution::Filter Result → ✅ Success::EstimatedGas({}): {}",
+				"-[{}] ⛓️  Execution::Filter Result → ✅ Success::EstimatedGas({}): {}",
 				sub_display_format(SUB_LOG_TARGET),
 				estimated_gas,
 				self.metadata

--- a/client/src/eth/handlers/execution_filter.rs
+++ b/client/src/eth/handlers/execution_filter.rs
@@ -1,0 +1,214 @@
+use br_primitives::{eth::GasCoefficient, sub_display_format};
+use ethers::{
+	providers::{JsonRpcClient, Middleware},
+	types::{TransactionRequest, U256},
+};
+use std::{sync::Arc, time::Duration};
+use tokio::time::sleep;
+
+use crate::eth::{
+	EthClient, EventMessage, EventMetadata, EventSender, SocketRelayMetadata, TxRequest,
+	DEFAULT_CALL_RETRIES, DEFAULT_CALL_RETRY_INTERVAL_MS,
+};
+
+use super::SocketRelayBuilder;
+
+const SUB_LOG_TARGET: &str = "execution-filter";
+
+/// The gas estimation result of the general message.
+enum EstimationResult {
+	/// The general message is executable. This contains the estimated gas amount.
+	Executable(U256),
+	/// The general message is non-executable. This contains the error message.
+	NonExecutable(String),
+}
+
+/// The task that tries to pre-gasEstimate the general message.
+/// This only handles requests that are relayed to the target client.
+/// (`client` and `event_sender` are connected to the same chain)
+pub struct ExecutionFilter<T> {
+	/// The `EthClient` to interact with the connected blockchain.
+	client: Arc<EthClient<T>>,
+	/// The event senders that sends messages to the event channel.
+	event_sender: Arc<EventSender>,
+	/// The metadata of the given socket message.
+	metadata: SocketRelayMetadata,
+}
+
+impl<T: JsonRpcClient> ExecutionFilter<T> {
+	/// Instantiates a new `ExecutionFilter`.
+	pub fn new(
+		client: Arc<EthClient<T>>,
+		event_sender: Arc<EventSender>,
+		metadata: SocketRelayMetadata,
+	) -> Self {
+		Self { client, event_sender, metadata }
+	}
+
+	/// Tries to gas estimate the general message and on success cases,
+	/// sends a transaction request to the event channel.
+	pub async fn try_filter_and_send(
+		&self,
+		tx_request: TransactionRequest,
+		give_random_delay: bool,
+		gas_coefficient: GasCoefficient,
+	) {
+		if let Some(executor_adddress) = self.client.protocol_contracts.executor_address {
+			log::info!(
+				target: &self.client.get_chain_name(),
+				"-[{}] ⛓️ Start Execution::Filter: {}",
+				sub_display_format(SUB_LOG_TARGET),
+				self.metadata
+			);
+
+			let general_msg = TxRequest::Legacy(
+				TransactionRequest::default()
+					.data(self.metadata.variants.clone().data)
+					.to(self.metadata.variants.receiver)
+					.from(executor_adddress),
+			);
+
+			let estimated_gas = match self.try_gas_estimation(general_msg).await {
+				EstimationResult::Executable(estimated_gas) => estimated_gas,
+				EstimationResult::NonExecutable(error) => {
+					log::warn!(
+						target: &self.client.get_chain_name(),
+						"-[{}] ⛓️ Execution::Filter Result → ❗️ Failure::Error({}): {}",
+						sub_display_format(SUB_LOG_TARGET),
+						error,
+						self.metadata
+					);
+					return;
+				},
+			};
+
+			log::info!(
+				target: &self.client.get_chain_name(),
+				"-[{}] ⛓️ Execution::Filter Result → ✅ Success::EstimatedGas({}): {}",
+				sub_display_format(SUB_LOG_TARGET),
+				estimated_gas,
+				self.metadata
+			);
+
+			self.request_send_transaction(tx_request, give_random_delay, gas_coefficient);
+		}
+	}
+
+	/// Requests a new transaction request to the event channel.
+	fn request_send_transaction(
+		&self,
+		tx_request: TransactionRequest,
+		give_random_delay: bool,
+		gas_coefficient: GasCoefficient,
+	) {
+		match self.event_sender.send(EventMessage::new(
+			TxRequest::Legacy(tx_request),
+			EventMetadata::SocketRelay(self.metadata.clone()),
+			true,
+			give_random_delay,
+			gas_coefficient,
+			self.metadata.is_bootstrap,
+		)) {
+			Ok(()) => {
+				log::info!(
+					target: &self.client.get_chain_name(),
+					"-[{}] 🔖 Request relay transaction to chain({:?}): {}",
+					sub_display_format(SUB_LOG_TARGET),
+					&self.client.get_chain_id(),
+					self.metadata
+				);
+			},
+			Err(error) => {
+				log::error!(
+					target: &self.client.get_chain_name(),
+					"-[{}] ❗️ Failed to send relay transaction to chain({:?}): {}, Error: {}",
+					sub_display_format(SUB_LOG_TARGET),
+					&self.client.get_chain_id(),
+					self.metadata,
+					error.to_string()
+				);
+				sentry::capture_message(
+					format!(
+						"[{}]-[{}]-[{}] ❗️ Failed to send relay transaction to chain({:?}): {}, Error: {}",
+						&self.client.get_chain_name(),
+						SUB_LOG_TARGET,
+						self.client.address(),
+						&self.client.get_chain_id(),
+						self.metadata,
+						error
+					)
+					.as_str(),
+					sentry::Level::Error,
+				);
+			},
+		}
+	}
+
+	/// Tries to gas estimate the given general message.
+	async fn try_gas_estimation(&self, general_msg: TxRequest) -> EstimationResult {
+		match self.client.provider.estimate_gas(&general_msg.to_typed(), None).await {
+			Ok(estimated_gas) => {
+				// this request is executable. now try to send the relay transaction.
+				EstimationResult::Executable(estimated_gas)
+			},
+			Err(error) => {
+				// this request is not executable. first, it'll be retried several times.
+				// if it still remains as failure, this request will be ignored and the `SocketRollbackHandler` might handle it.
+				self.handle_failed_gas_estimation(&general_msg, error.to_string()).await
+			},
+		}
+	}
+
+	/// Handles the failed gas estimation.
+	async fn handle_failed_gas_estimation(
+		&self,
+		tx_request: &TxRequest,
+		error: String,
+	) -> EstimationResult {
+		let mut retries = DEFAULT_CALL_RETRIES;
+		let mut last_error = error;
+
+		while retries > 0 {
+			br_metrics::increase_rpc_calls(&self.client.get_chain_name());
+
+			if self.client.debug_mode {
+				log::warn!(
+					target: &self.client.get_chain_name(),
+					"-[{}] ⚠️  Warning! Error encountered during gas estimation, Retries left: {:?}, Error: {}",
+					sub_display_format(SUB_LOG_TARGET),
+					retries - 1,
+					last_error
+				);
+				sentry::capture_message(
+					format!(
+						"[{}]-[{}]-[{}] ⚠️  Warning! Error encountered during gas estimation, Retries left: {:?}, Error: {}",
+						&self.client.get_chain_name(),
+						SUB_LOG_TARGET,
+						self.client.address(),
+						retries - 1,
+						last_error
+					)
+					.as_str(),
+					sentry::Level::Warning,
+				);
+			}
+
+			match self.client.provider.estimate_gas(&tx_request.to_typed(), None).await {
+				Ok(estimated_gas) => return EstimationResult::Executable(estimated_gas),
+				Err(error) => {
+					sleep(Duration::from_millis(DEFAULT_CALL_RETRY_INTERVAL_MS)).await;
+					retries -= 1;
+					last_error = error.to_string();
+				},
+			}
+		}
+		EstimationResult::NonExecutable(last_error)
+	}
+}
+
+#[async_trait::async_trait]
+impl<T: JsonRpcClient> SocketRelayBuilder<T> for ExecutionFilter<T> {
+	fn get_client(&self) -> Arc<EthClient<T>> {
+		self.client.clone()
+	}
+}

--- a/client/src/eth/handlers/mod.rs
+++ b/client/src/eth/handlers/mod.rs
@@ -1,5 +1,5 @@
 use br_primitives::{
-	eth::{BuiltRelayTransaction, ChainID, RecoveredSignature},
+	eth::{BuiltRelayTransaction, ChainID, RecoveredSignature, SocketVariants},
 	socket::{PollSubmit, Signatures, SocketMessage},
 };
 use ethers::{
@@ -9,11 +9,13 @@ use ethers::{
 };
 use std::{str::FromStr, sync::Arc};
 
+pub use execution_filter::*;
 pub use roundup_relay_handler::*;
 pub use socket_relay_handler::*;
 
 use super::EthClient;
 
+mod execution_filter;
 mod roundup_relay_handler;
 mod socket_relay_handler;
 
@@ -104,6 +106,11 @@ pub trait SocketRelayBuilder<T> {
 			ins_code_token,
 			params_token,
 		])])
+	}
+
+	/// Decodes the raw variants in the socket message.
+	fn decode_msg_variants(&self, _raw_variants: &Bytes) -> SocketVariants {
+		SocketVariants::default()
 	}
 
 	/// Signs the given socket message.

--- a/client/src/eth/handlers/mod.rs
+++ b/client/src/eth/handlers/mod.rs
@@ -1,7 +1,18 @@
-use ethers::types::{Log, H256};
+use br_primitives::{
+	eth::{BuiltRelayTransaction, ChainID, RecoveredSignature},
+	socket::{PollSubmit, Signatures, SocketMessage},
+};
+use ethers::{
+	abi::Token,
+	providers::JsonRpcClient,
+	types::{Bytes, Log, Signature, H256, U256},
+};
+use std::{str::FromStr, sync::Arc};
 
 pub use roundup_relay_handler::*;
 pub use socket_relay_handler::*;
+
+use super::EthClient;
 
 mod roundup_relay_handler;
 mod socket_relay_handler;
@@ -19,4 +30,133 @@ pub trait Handler {
 
 	/// Verifies whether the given event topic matches the target event signature.
 	fn is_target_event(&self, topic: H256) -> bool;
+}
+
+#[async_trait::async_trait]
+/// The client to interact with the `Socket` contract instance.
+pub trait SocketRelayBuilder<T> {
+	/// Get the `EthClient` of the implemented handler.
+	fn get_client(&self) -> Arc<EthClient<T>>;
+
+	/// Builds the `poll()` function call data.
+	fn build_poll_call_data(&self, msg: SocketMessage, sigs: Signatures) -> Bytes
+	where
+		T: JsonRpcClient,
+	{
+		let poll_submit = PollSubmit { msg, sigs, option: U256::default() };
+		self.get_client()
+			.protocol_contracts
+			.socket
+			.poll(poll_submit)
+			.calldata()
+			.unwrap()
+	}
+
+	/// Builds the `poll()` transaction request.
+	///
+	/// This method returns an `Option` in order to bypass unknown chain events.
+	/// Possibly can happen when a new chain definition hasn't been added to the operator's config.
+	async fn build_transaction(
+		&self,
+		_msg: SocketMessage,
+		_is_inbound: bool,
+		_relay_tx_chain_id: ChainID,
+	) -> Option<BuiltRelayTransaction> {
+		None
+	}
+
+	/// Build the signatures required to request an inbound `poll()` and returns a flag which represents
+	/// whether the relay transaction should be processed to an external chain.
+	async fn build_inbound_signatures(&self, _msg: SocketMessage) -> (Signatures, bool) {
+		(Signatures::default(), false)
+	}
+
+	/// Build the signatures required to request an outbound `poll()` and returns a flag which represents
+	/// whether the relay transaction should be processed to an external chain.
+	async fn build_outbound_signatures(&self, _msg: SocketMessage) -> (Signatures, bool) {
+		(Signatures::default(), false)
+	}
+
+	/// Encodes the given socket message to bytes.
+	fn encode_socket_message(&self, msg: SocketMessage) -> Vec<u8> {
+		let req_id_token = Token::Tuple(vec![
+			Token::FixedBytes(msg.req_id.chain.into()),
+			Token::Uint(msg.req_id.round_id.into()),
+			Token::Uint(msg.req_id.sequence.into()),
+		]);
+		let status_token = Token::Uint(msg.status.into());
+		let ins_code_token = Token::Tuple(vec![
+			Token::FixedBytes(msg.ins_code.chain.into()),
+			Token::FixedBytes(msg.ins_code.method.into()),
+		]);
+		let params_token = Token::Tuple(vec![
+			Token::FixedBytes(msg.params.token_idx0.into()),
+			Token::FixedBytes(msg.params.token_idx1.into()),
+			Token::Address(msg.params.refund),
+			Token::Address(msg.params.to),
+			Token::Uint(msg.params.amount),
+			Token::Bytes(msg.params.variants.to_vec()),
+		]);
+
+		ethers::abi::encode(&[Token::Tuple(vec![
+			req_id_token,
+			status_token,
+			ins_code_token,
+			params_token,
+		])])
+	}
+
+	/// Signs the given socket message.
+	fn sign_socket_message(&self, msg: SocketMessage) -> Signature {
+		let encoded_msg = self.encode_socket_message(msg);
+		self.get_client().wallet.sign_message(&encoded_msg)
+	}
+
+	/// Get the signatures of the given message.
+	async fn get_sorted_signatures(&self, msg: SocketMessage) -> Signatures
+	where
+		T: JsonRpcClient,
+	{
+		let raw_sigs = self
+			.get_client()
+			.contract_call(
+				self.get_client()
+					.protocol_contracts
+					.socket
+					.get_signatures(msg.clone().req_id, msg.clone().status),
+				"socket.get_signatures",
+			)
+			.await;
+
+		let raw_concated_v = &raw_sigs.v.to_string()[2..];
+
+		let mut recovered_sigs = vec![];
+		let encoded_msg = self.encode_socket_message(msg);
+		for idx in 0..raw_sigs.r.len() {
+			let sig = Signature {
+				r: raw_sigs.r[idx].into(),
+				s: raw_sigs.s[idx].into(),
+				v: u64::from_str_radix(&raw_concated_v[idx * 2..idx * 2 + 2], 16).unwrap(),
+			};
+			recovered_sigs.push(RecoveredSignature::new(
+				idx,
+				sig,
+				self.get_client().wallet.recover_message(sig, &encoded_msg),
+			));
+		}
+		recovered_sigs.sort_by_key(|k| k.signer);
+
+		let mut sorted_sigs = Signatures::default();
+		let mut sorted_concated_v = String::from("0x");
+		recovered_sigs.into_iter().for_each(|sig| {
+			let idx = sig.idx;
+			sorted_sigs.r.push(raw_sigs.r[idx]);
+			sorted_sigs.s.push(raw_sigs.s[idx]);
+			let v = Bytes::from([sig.signature.v as u8]);
+			sorted_concated_v.push_str(&v.to_string()[2..]);
+		});
+		sorted_sigs.v = Bytes::from_str(&sorted_concated_v).unwrap();
+
+		sorted_sigs
+	}
 }

--- a/client/src/eth/handlers/roundup_relay_handler.rs
+++ b/client/src/eth/handlers/roundup_relay_handler.rs
@@ -157,10 +157,10 @@ impl<T: JsonRpcClient> RoundupRelayHandler<T> {
 		// Only broadcast to external chains
 		event_senders_vec.retain(|channel| !channel.is_native);
 
-		let mut event_senders = BTreeMap::new();
-		event_senders_vec.iter().for_each(|event_sender| {
-			event_senders.insert(event_sender.id, event_sender.clone());
-		});
+		let event_senders: BTreeMap<ChainID, Arc<EventSender>> = event_senders_vec
+			.iter()
+			.map(|event_sender| (event_sender.id, event_sender.clone()))
+			.collect();
 
 		let client = clients
 			.iter()

--- a/client/src/eth/handlers/socket_relay_handler.rs
+++ b/client/src/eth/handlers/socket_relay_handler.rs
@@ -283,7 +283,7 @@ impl<T: 'static + JsonRpcClient> SocketRelayHandler<T> {
 	pub fn new(
 		id: ChainID,
 		event_senders_vec: Vec<Arc<EventSender>>,
-		rollback_senders_vec: Vec<Arc<RollbackSender>>,
+		rollback_senders: BTreeMap<ChainID, Arc<RollbackSender>>,
 		block_receiver: Receiver<BlockMessage>,
 		system_clients_vec: Vec<Arc<EthClient<T>>>,
 		bootstrap_shared_data: Arc<BootstrapSharedData>,
@@ -299,11 +299,6 @@ impl<T: 'static + JsonRpcClient> SocketRelayHandler<T> {
 		let event_senders: BTreeMap<ChainID, Arc<EventSender>> = event_senders_vec
 			.iter()
 			.map(|event_sender| (event_sender.id, event_sender.clone()))
-			.collect();
-
-		let rollback_senders: BTreeMap<ChainID, Arc<RollbackSender>> = rollback_senders_vec
-			.iter()
-			.map(|rollback_sender| (rollback_sender.id, rollback_sender.clone()))
 			.collect();
 
 		Self {

--- a/client/src/eth/handlers/socket_relay_handler.rs
+++ b/client/src/eth/handlers/socket_relay_handler.rs
@@ -234,7 +234,7 @@ impl<T: JsonRpcClient> SocketRelayBuilder<T> for SocketRelayHandler<T> {
 					ParamType::Uint(256),
 					ParamType::Bytes,
 				],
-				&raw_variants,
+				raw_variants,
 			) {
 				Ok(variants) => {
 					let mut result = SocketVariants::default();

--- a/client/src/eth/handlers/socket_relay_handler.rs
+++ b/client/src/eth/handlers/socket_relay_handler.rs
@@ -289,22 +289,22 @@ impl<T: 'static + JsonRpcClient> SocketRelayHandler<T> {
 		bootstrap_shared_data: Arc<BootstrapSharedData>,
 		execute_spawn_handle: SpawnTaskHandle,
 	) -> Self {
-		let mut system_clients = BTreeMap::new();
-		system_clients_vec.iter().for_each(|client| {
-			system_clients.insert(client.get_chain_id(), client.clone());
-		});
+		let system_clients: BTreeMap<ChainID, Arc<EthClient<T>>> = system_clients_vec
+			.iter()
+			.map(|client| (client.get_chain_id(), client.clone()))
+			.collect();
 
 		let client = system_clients.get(&id).expect(INVALID_CHAIN_ID).clone();
 
-		let mut event_senders = BTreeMap::new();
-		event_senders_vec.iter().for_each(|event_sender| {
-			event_senders.insert(event_sender.id, event_sender.clone());
-		});
+		let event_senders: BTreeMap<ChainID, Arc<EventSender>> = event_senders_vec
+			.iter()
+			.map(|event_sender| (event_sender.id, event_sender.clone()))
+			.collect();
 
-		let mut rollback_senders = BTreeMap::new();
-		rollback_senders_vec.iter().for_each(|rollback_sender| {
-			rollback_senders.insert(rollback_sender.id, rollback_sender.clone());
-		});
+		let rollback_senders: BTreeMap<ChainID, Arc<RollbackSender>> = rollback_senders_vec
+			.iter()
+			.map(|rollback_sender| (rollback_sender.id, rollback_sender.clone()))
+			.collect();
 
 		Self {
 			event_senders,

--- a/client/src/eth/tx/eip1559_manager.rs
+++ b/client/src/eth/tx/eip1559_manager.rs
@@ -27,7 +27,7 @@ use tokio::{
 	time::sleep,
 };
 
-use super::{generate_delay, AsyncTransactionTask};
+use super::{generate_delay, TransactionTask};
 
 const SUB_LOG_TARGET: &str = "eip1559-tx-manager";
 
@@ -226,7 +226,7 @@ impl<T: JsonRpcClient> Eip1559TransactionTask<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: JsonRpcClient> AsyncTransactionTask<T> for Eip1559TransactionTask<T> {
+impl<T: JsonRpcClient> TransactionTask<T> for Eip1559TransactionTask<T> {
 	fn is_txpool_enabled(&self) -> bool {
 		self.is_txpool_enabled
 	}

--- a/client/src/eth/tx/eip1559_manager.rs
+++ b/client/src/eth/tx/eip1559_manager.rs
@@ -244,6 +244,8 @@ impl<T: JsonRpcClient> TransactionTask<T> for Eip1559TransactionTask<T> {
 	}
 
 	async fn try_send_transaction(&self, mut msg: EventMessage) {
+		msg.tx_request = TxRequest::Eip1559(msg.tx_request.to_eip1559());
+
 		if msg.retries_remaining == 0 {
 			return;
 		}

--- a/client/src/eth/tx/legacy_manager.rs
+++ b/client/src/eth/tx/legacy_manager.rs
@@ -228,7 +228,7 @@ pub struct LegacyTransactionTask<T> {
 	is_initially_escalated: bool,
 	/// The coefficient used on transaction gas price escalation (default: 1.15)
 	gas_price_coefficient: f64,
-	/// The minimum value use for gas_price. (default: 0)
+	/// The minimum value used for gas_price. (default: 0)
 	min_gas_price: U256,
 	/// If first relay transaction is stuck in mempool after waiting for this amount of time(ms),
 	/// ignore duplicate prevent logic. (default: 12s)

--- a/client/src/eth/tx/legacy_manager.rs
+++ b/client/src/eth/tx/legacy_manager.rs
@@ -27,7 +27,7 @@ use tokio::{
 	time::sleep,
 };
 
-use super::{generate_delay, AsyncTransactionTask};
+use super::{generate_delay, TransactionTask};
 
 const SUB_LOG_TARGET: &str = "legacy-tx-manager";
 
@@ -259,7 +259,7 @@ impl<T: JsonRpcClient> LegacyTransactionTask<T> {
 }
 
 #[async_trait::async_trait]
-impl<T: JsonRpcClient> AsyncTransactionTask<T> for LegacyTransactionTask<T> {
+impl<T: JsonRpcClient> TransactionTask<T> for LegacyTransactionTask<T> {
 	fn is_txpool_enabled(&self) -> bool {
 		self.is_txpool_enabled
 	}

--- a/client/src/eth/tx/task.rs
+++ b/client/src/eth/tx/task.rs
@@ -11,7 +11,7 @@ use tokio::time::sleep;
 use crate::eth::{EthClient, EventMessage, EventMetadata, TxRequest};
 
 #[async_trait::async_trait]
-pub trait AsyncTransactionTask<T>
+pub trait TransactionTask<T>
 where
 	T: JsonRpcClient,
 {

--- a/periodic/src/heartbeat_sender.rs
+++ b/periodic/src/heartbeat_sender.rs
@@ -73,7 +73,10 @@ impl<T: JsonRpcClient> PeriodicWorker for HeartbeatSender<T> {
 
 impl<T: JsonRpcClient> HeartbeatSender<T> {
 	/// Instantiates a new `HeartbeatSender` instance.
-	pub fn new(client: Arc<EthClient<T>>, event_senders: Vec<Arc<EventSender>>) -> Self {
+	pub fn new(
+		event_senders: Vec<Arc<EventSender>>,
+		system_clients: Vec<Arc<EthClient<T>>>,
+	) -> Self {
 		Self {
 			schedule: Schedule::from_str(HEARTBEAT_SCHEDULE).expect(INVALID_PERIODIC_SCHEDULE),
 			event_sender: event_senders
@@ -81,7 +84,11 @@ impl<T: JsonRpcClient> HeartbeatSender<T> {
 				.find(|channel| channel.is_native)
 				.expect(INVALID_BIFROST_NATIVENESS)
 				.clone(),
-			client,
+			client: system_clients
+				.iter()
+				.find(|client| client.metadata.is_native)
+				.expect(INVALID_BIFROST_NATIVENESS)
+				.clone(),
 		}
 	}
 

--- a/periodic/src/heartbeat_sender.rs
+++ b/periodic/src/heartbeat_sender.rs
@@ -30,6 +30,8 @@ impl<T: JsonRpcClient> PeriodicWorker for HeartbeatSender<T> {
 
 	async fn run(&mut self) {
 		loop {
+			self.wait_until_next_time().await;
+
 			let address = self.client.address();
 
 			let relayer_manager = self.client.protocol_contracts.relayer_manager.as_ref().unwrap();
@@ -65,8 +67,6 @@ impl<T: JsonRpcClient> PeriodicWorker for HeartbeatSender<T> {
 				)
 				.await;
 			}
-
-			self.wait_until_next_time().await;
 		}
 	}
 }

--- a/periodic/src/heartbeat_sender.rs
+++ b/periodic/src/heartbeat_sender.rs
@@ -30,8 +30,6 @@ impl<T: JsonRpcClient> PeriodicWorker for HeartbeatSender<T> {
 
 	async fn run(&mut self) {
 		loop {
-			self.wait_until_next_time().await;
-
 			let address = self.client.address();
 
 			let relayer_manager = self.client.protocol_contracts.relayer_manager.as_ref().unwrap();
@@ -67,6 +65,8 @@ impl<T: JsonRpcClient> PeriodicWorker for HeartbeatSender<T> {
 				)
 				.await;
 			}
+
+			self.wait_until_next_time().await;
 		}
 	}
 }

--- a/periodic/src/lib.rs
+++ b/periodic/src/lib.rs
@@ -2,5 +2,6 @@ pub mod heartbeat_sender;
 pub mod price_feeder;
 mod price_source;
 pub mod roundup_emitter;
+pub mod socket_rollback_handler;
 
 pub use price_feeder::*;

--- a/periodic/src/socket_rollback_handler.rs
+++ b/periodic/src/socket_rollback_handler.rs
@@ -70,6 +70,8 @@ impl<T: JsonRpcClient> SocketRollbackHandler<T> {
 			)
 			.await;
 
+		// TODO: check both source & dst chain request status. none= 0
+
 		// If the state has changed, we consider that it has been executed (or rejected).
 		// `socket_msg.status` will either be `Inbound::Requested` or `Outbound::Accepted`.
 		if SocketEventStatus::from_u8(socket_msg.status)

--- a/periodic/src/socket_rollback_handler.rs
+++ b/periodic/src/socket_rollback_handler.rs
@@ -127,7 +127,7 @@ impl<T: JsonRpcClient> SocketRollbackHandler<T> {
 		req_id: &RequestID,
 		chain_id: ChainID,
 	) -> Option<RequestInfo> {
-		if let Some(client) = &self.system_clients.get(&chain_id) {
+		if let Some(client) = self.system_clients.get(&chain_id) {
 			return Some(
 				client
 					.contract_call(

--- a/periodic/src/socket_rollback_handler.rs
+++ b/periodic/src/socket_rollback_handler.rs
@@ -105,7 +105,7 @@ impl<T: JsonRpcClient> SocketRollbackHandler<T> {
 
 	/// Verifies whether the socket event is an inbound sequence.
 	fn is_inbound_sequence(&self, dst_chain_id: ChainID) -> bool {
-		if let Some(client) = &self.system_clients.get(&dst_chain_id) {
+		if let Some(client) = self.system_clients.get(&dst_chain_id) {
 			return matches!(client.metadata.if_destination_chain, RelayDirection::Inbound);
 		}
 		false

--- a/periodic/src/socket_rollback_handler.rs
+++ b/periodic/src/socket_rollback_handler.rs
@@ -46,7 +46,7 @@ impl<T: JsonRpcClient> SocketRollbackHandler<T> {
 	) -> (Self, UnboundedSender<SocketMessage>) {
 		let (sender, rollback_receiver) = mpsc::unbounded_channel::<SocketMessage>();
 
-		let system_clients: BTreeMap<_, _> = system_clients_vec
+		let system_clients: BTreeMap<ChainID, Arc<EthClient<T>>> = system_clients_vec
 			.iter()
 			.map(|client| (client.get_chain_id(), client.clone()))
 			.collect();

--- a/periodic/src/socket_rollback_handler.rs
+++ b/periodic/src/socket_rollback_handler.rs
@@ -46,10 +46,10 @@ impl<T: JsonRpcClient> SocketRollbackHandler<T> {
 	) -> (Self, UnboundedSender<SocketMessage>) {
 		let (sender, rollback_receiver) = mpsc::unbounded_channel::<SocketMessage>();
 
-		let mut system_clients = BTreeMap::new();
-		system_clients_vec.iter().for_each(|client| {
-			system_clients.insert(client.get_chain_id(), client.clone());
-		});
+		let system_clients: BTreeMap<_, _> = system_clients_vec
+			.iter()
+			.map(|client| (client.get_chain_id(), client.clone()))
+			.collect();
 
 		(
 			Self {

--- a/periodic/src/socket_rollback_handler.rs
+++ b/periodic/src/socket_rollback_handler.rs
@@ -1,0 +1,256 @@
+use std::{collections::BTreeMap, str::FromStr, sync::Arc};
+
+use br_client::eth::{
+	EthClient, EventMessage, EventMetadata, EventSender, RollbackMetadata, SocketRelayBuilder,
+	TxRequest,
+};
+use br_primitives::{
+	eth::{ChainID, GasCoefficient, SocketEventStatus},
+	socket::{PollSubmit, Signatures, SocketMessage},
+	sub_display_format, PeriodicWorker, RawRequestID, RollbackableMessage, INVALID_CHAIN_ID,
+	INVALID_PERIODIC_SCHEDULE, ROLLBACK_CHECK_MINIMUM_INTERVAL, ROLLBACK_CHECK_SCHEDULE,
+};
+use cron::Schedule;
+use ethers::{
+	providers::JsonRpcClient,
+	types::{TransactionRequest, U256},
+};
+use tokio::sync::mpsc::{self, UnboundedReceiver, UnboundedSender};
+
+const SUB_LOG_TARGET: &str = "rollback-handler";
+
+/// The essential task that handles `Socket` event rollbacks.
+/// This only handles requests that are relayed to the target client.
+/// (`client` and `event_sender` are connected to the same chain)
+pub struct SocketRollbackHandler<T> {
+	/// The `EthClient` to interact with the connected blockchain.
+	pub client: Arc<EthClient<T>>,
+	/// The receiver connected to the socket rollback channel.
+	rollback_receiver: UnboundedReceiver<SocketMessage>,
+	/// The local storage saving emitted `Socket` event messages.
+	rollback_msgs: BTreeMap<RawRequestID, RollbackableMessage>,
+	/// The event senders that sends messages to the event channel.
+	event_sender: Arc<EventSender>,
+	/// The time schedule that represents when to check heartbeat pulsed.
+	schedule: Schedule,
+}
+
+impl<T: JsonRpcClient> SocketRollbackHandler<T> {
+	/// Instantiates a new `SocketRollbackHandler`.
+	pub fn new(
+		event_sender: Arc<EventSender>,
+		system_clients: Vec<Arc<EthClient<T>>>,
+	) -> (Self, UnboundedSender<SocketMessage>) {
+		let (sender, rollback_receiver) = mpsc::unbounded_channel::<SocketMessage>();
+
+		(
+			Self {
+				client: system_clients
+					.iter()
+					.find(|client| client.get_chain_id() == event_sender.id)
+					.expect(INVALID_CHAIN_ID)
+					.clone(),
+				rollback_receiver,
+				rollback_msgs: BTreeMap::new(),
+				event_sender,
+				schedule: Schedule::from_str(ROLLBACK_CHECK_SCHEDULE)
+					.expect(INVALID_PERIODIC_SCHEDULE),
+			},
+			sender,
+		)
+	}
+
+	/// Verifies whether the given socket message has been executed or reverted.
+	async fn is_request_executed(&self, socket_msg: &SocketMessage) -> bool {
+		let request = self
+			.client
+			.contract_call(
+				self.client.protocol_contracts.socket.get_request(socket_msg.req_id.clone()),
+				"socket.get_request",
+			)
+			.await;
+
+		// If the state has changed, we consider that it has been executed (or rejected).
+		// `socket_msg.status` will either be `Inbound::Requested` or `Outbound::Accepted`.
+		if SocketEventStatus::from_u8(socket_msg.status)
+			!= SocketEventStatus::from_u8(request.field[0].clone().into())
+		{
+			return true;
+		}
+		false
+	}
+
+	/// Verifies whether a certain socket message has been waited for at least the required minimum time.
+	fn is_interval_passed(&self, requested_timestamp: U256, current_timestamp: U256) -> bool {
+		if current_timestamp.saturating_sub(requested_timestamp)
+			>= ROLLBACK_CHECK_MINIMUM_INTERVAL.into()
+		{
+			return true;
+		}
+		false
+	}
+
+	/// Tries to rollback the given socket message.
+	async fn try_rollback(&self, socket_msg: &SocketMessage) {
+		let status = SocketEventStatus::from_u8(socket_msg.status);
+		match status {
+			SocketEventStatus::Requested => self.try_rollback_inbound(socket_msg).await,
+			SocketEventStatus::Accepted => self.try_rollback_outbound(socket_msg).await,
+			_ => panic!("Trying rollback on an invalid socket event status"),
+		}
+	}
+
+	/// Tries to rollback the given inbound socket message.
+	async fn try_rollback_inbound(&self, socket_msg: &SocketMessage) {
+		let mut submit_sig = socket_msg.clone();
+		submit_sig.status = SocketEventStatus::Failed.into();
+		let poll_submit = PollSubmit {
+			msg: submit_sig.clone(),
+			sigs: Signatures::default(),
+			option: U256::default(),
+		};
+		let call_data = self.client.protocol_contracts.socket.poll(poll_submit).calldata().unwrap();
+		let tx_request = TransactionRequest::default().data(call_data).to(self
+			.client
+			.protocol_contracts
+			.socket
+			.address());
+
+		let metadata = RollbackMetadata::new(
+			true,
+			SocketEventStatus::Failed,
+			socket_msg.req_id.sequence,
+			ChainID::from_be_bytes(socket_msg.req_id.chain),
+			ChainID::from_be_bytes(socket_msg.ins_code.chain),
+		);
+
+		self.request_send_transaction(tx_request, metadata, false, GasCoefficient::Mid);
+	}
+
+	/// Tries to rollback the given outbound socket message.
+	async fn try_rollback_outbound(&self, socket_msg: &SocketMessage) {
+		// `submit_sig` is the state changed socket message that will be passed.
+		// `socket_msg` is the origin message that will be used for signature builds.
+		let mut submit_sig = socket_msg.clone();
+		submit_sig.status = SocketEventStatus::Rejected.into();
+		let tx_request = TransactionRequest::default()
+			.data(self.build_poll_call_data(
+				submit_sig.clone(),
+				self.get_sorted_signatures(socket_msg.clone()).await,
+			))
+			.to(self.client.protocol_contracts.socket.address());
+
+		let metadata = RollbackMetadata::new(
+			false,
+			SocketEventStatus::Rejected,
+			socket_msg.req_id.sequence,
+			ChainID::from_be_bytes(socket_msg.req_id.chain),
+			ChainID::from_be_bytes(socket_msg.ins_code.chain),
+		);
+
+		self.request_send_transaction(tx_request, metadata, true, GasCoefficient::Low);
+	}
+
+	/// Tries to receive any new rollbackable messages and store's it locally.
+	fn receive(&mut self, current_timestamp: U256) {
+		while let Ok(msg) = self.rollback_receiver.try_recv() {
+			let req_id = msg.req_id.sequence;
+			if self.rollback_msgs.contains_key(&req_id) {
+				continue;
+			}
+			self.rollback_msgs
+				.insert(req_id, RollbackableMessage::new(current_timestamp, msg));
+		}
+	}
+
+	/// Request a socket rollback transaction to the target event channel.
+	fn request_send_transaction(
+		&self,
+		tx_request: TransactionRequest,
+		metadata: RollbackMetadata,
+		give_random_delay: bool,
+		gas_coefficient: GasCoefficient,
+	) {
+		match self.event_sender.send(EventMessage::new(
+			TxRequest::Legacy(tx_request),
+			EventMetadata::Rollback(metadata.clone()),
+			true,
+			give_random_delay,
+			gas_coefficient,
+			false,
+		)) {
+			Ok(()) => {
+				log::info!(
+					target: &self.client.get_chain_name(),
+					"-[{}] 🔃 Try Rollback::Socket: {}",
+					sub_display_format(SUB_LOG_TARGET),
+					metadata
+				);
+			},
+			Err(error) => {
+				log::error!(
+					target: &self.client.get_chain_name(),
+					"-[{}] ❗️ Failed to try Rollback::Socket: {}, Error: {}",
+					sub_display_format(SUB_LOG_TARGET),
+					metadata,
+					error.to_string()
+				);
+				sentry::capture_message(
+					format!(
+						"[{}]-[{}]-[{}] ❗️ Failed to try Rollback::Socket: {}, Error: {}",
+						&self.client.get_chain_name(),
+						SUB_LOG_TARGET,
+						self.client.address(),
+						metadata,
+						error
+					)
+					.as_str(),
+					sentry::Level::Error,
+				);
+			},
+		}
+	}
+}
+
+#[async_trait::async_trait]
+impl<T: JsonRpcClient> SocketRelayBuilder<T> for SocketRollbackHandler<T> {
+	fn get_client(&self) -> Arc<EthClient<T>> {
+		self.client.clone()
+	}
+}
+
+#[async_trait::async_trait]
+impl<T: JsonRpcClient> PeriodicWorker for SocketRollbackHandler<T> {
+	fn schedule(&self) -> Schedule {
+		self.schedule.clone()
+	}
+
+	async fn run(&mut self) {
+		loop {
+			// executed or rollback handled request ID's.
+			let mut handled_req_ids = vec![];
+
+			if let Some(latest_block) =
+				self.client.get_block(self.client.get_latest_block_number().await.into()).await
+			{
+				self.receive(latest_block.timestamp);
+
+				for (req_id, rollback_msg) in self.rollback_msgs.clone() {
+					if !self.is_interval_passed(rollback_msg.timestamp, latest_block.timestamp) {
+						continue;
+					}
+					if !self.is_request_executed(&rollback_msg.socket_msg).await {
+						// the pending request has not been processed through the schedule. rollback should be handled.
+						self.try_rollback(&rollback_msg.socket_msg).await;
+					}
+					handled_req_ids.push(req_id);
+				}
+				for req_id in handled_req_ids {
+					self.rollback_msgs.remove(&req_id);
+				}
+			}
+
+			self.wait_until_next_time().await;
+		}
+	}
+}

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -105,6 +105,8 @@ pub struct EVMProvider {
 	pub authority_address: String,
 	/// Relayer manager contract address (Bifrost only)
 	pub relayer_manager_address: Option<String>,
+	/// The executor contract address for CCCP version 2.
+	pub executor_address: Option<String>,
 	/// Chainlink usdc/usd aggregator
 	pub chainlink_usdc_usd_address: Option<String>,
 	/// Chainlink usdt/usd aggregator

--- a/primitives/src/contracts/socket.rs
+++ b/primitives/src/contracts/socket.rs
@@ -6,8 +6,6 @@ use ethers::{
 	types::{Bytes, Signature, U256},
 };
 
-use crate::eth::{BuiltRelayTransaction, ChainID};
-
 abigen!(
 	SocketContract,
 	"../abi/abi.socket.merged.json",
@@ -157,41 +155,4 @@ impl From<Signature> for Signatures {
 		let v: [u8; 1] = [signature.v as u8];
 		Signatures { r: vec![r], s: vec![s], v: Bytes::from(v) }
 	}
-}
-
-#[async_trait::async_trait]
-/// The client to interact with the `Socket` contract instance.
-pub trait SocketRelayBuilder {
-	/// Builds the `poll()` function call data.
-	fn build_poll_call_data(&self, msg: SocketMessage, sigs: Signatures) -> Bytes;
-
-	/// Builds the `poll()` transaction request. `submit_msg` is the `Socket` event message used for transaction submission
-	/// and `sig_msg` is the `Socket` event message used for signature construction.
-	///
-	/// This method returns an `Option` in order to bypass unknown chain events.
-	/// Possibly can happen when a new chain definition hasn't been added to the operator's config.
-	async fn build_transaction(
-		&self,
-		submit_msg: SocketMessage,
-		sig_msg: SocketMessage,
-		is_inbound: bool,
-		relay_tx_chain_id: ChainID,
-	) -> Option<BuiltRelayTransaction>;
-
-	/// Build the signatures required to request an inbound `poll()` and returns a flag which represents
-	/// whether the relay transaction should be processed to an external chain.
-	async fn build_inbound_signatures(&self, msg: SocketMessage) -> (Signatures, bool);
-
-	/// Build the signatures required to request an outbound `poll()` and returns a flag which represents
-	/// whether the relay transaction should be processed to an external chain.
-	async fn build_outbound_signatures(&self, msg: SocketMessage) -> (Signatures, bool);
-
-	/// Encodes the given socket message to bytes.
-	fn encode_socket_message(&self, msg: SocketMessage) -> Vec<u8>;
-
-	/// Signs the given socket message.
-	fn sign_socket_message(&self, msg: SocketMessage) -> Signature;
-
-	/// Get the signatures of the given message.
-	async fn get_sorted_signatures(&self, msg: SocketMessage) -> Signatures;
 }

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -197,7 +197,8 @@ impl RoundUpEventStatus {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd)]
 /// The socket event status.
 pub enum SocketEventStatus {
-	Requested = 1,
+	None,
+	Requested,
 	Failed,
 	Executed,
 	Reverted,
@@ -210,6 +211,7 @@ pub enum SocketEventStatus {
 impl SocketEventStatus {
 	pub fn from_u8(status: u8) -> Self {
 		match status {
+			0 => SocketEventStatus::None,
 			1 => SocketEventStatus::Requested,
 			2 => SocketEventStatus::Failed,
 			3 => SocketEventStatus::Executed,
@@ -226,6 +228,7 @@ impl SocketEventStatus {
 impl From<SocketEventStatus> for u8 {
 	fn from(status: SocketEventStatus) -> Self {
 		match status {
+			SocketEventStatus::None => 0,
 			SocketEventStatus::Requested => 1,
 			SocketEventStatus::Failed => 2,
 			SocketEventStatus::Executed => 3,

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -2,7 +2,7 @@ use std::{str::FromStr, sync::Arc};
 
 use ethers::{
 	providers::{JsonRpcClient, Provider},
-	types::{Address, Signature, TransactionRequest, H160, U64},
+	types::{Address, Bytes, Signature, TransactionRequest, H160, U256, U64},
 };
 
 use crate::{
@@ -24,6 +24,13 @@ pub const BOOTSTRAP_BLOCK_CHUNK_SIZE: u64 = 2000;
 
 /// The block offset used to measure the average block time at bootstrap.
 pub const BOOTSTRAP_BLOCK_OFFSET: u32 = 100;
+
+#[derive(Clone, Debug)]
+/// The protocol version of the CCCP Socket message.
+pub enum SocketVersion {
+	V1,
+	V2,
+}
 
 /// The metadata of the EVM provider.
 pub struct ProviderMetadata {
@@ -114,6 +121,8 @@ pub struct ProtocolContracts<T> {
 	pub authority: AuthorityContract<Provider<T>>,
 	/// RelayerManagerContract (Bifrost only)
 	pub relayer_manager: Option<RelayerManagerContract<Provider<T>>>,
+	/// The CCCP v2 Execution contract address.
+	pub executor_address: Option<Address>,
 }
 
 impl<T: JsonRpcClient> ProtocolContracts<T> {
@@ -122,6 +131,7 @@ impl<T: JsonRpcClient> ProtocolContracts<T> {
 		socket_address: String,
 		authority_address: String,
 		relayer_manager_address: Option<String>,
+		executor_address: Option<String>,
 	) -> Self {
 		Self {
 			socket: SocketContract::new(
@@ -138,6 +148,8 @@ impl<T: JsonRpcClient> ProtocolContracts<T> {
 					provider.clone(),
 				)
 			}),
+			executor_address: executor_address
+				.map(|address| Address::from_str(&address).expect(INVALID_CONTRACT_ADDRESS)),
 		}
 	}
 }
@@ -222,6 +234,27 @@ impl From<SocketEventStatus> for u8 {
 			SocketEventStatus::Rejected => 6,
 			SocketEventStatus::Committed => 7,
 			SocketEventStatus::Rollbacked => 8,
+		}
+	}
+}
+
+#[derive(Clone, Debug)]
+pub struct SocketVariants {
+	pub source_chain: Bytes,
+	pub receiver: Address,
+	pub max_fee: U256,
+	pub data: Bytes,
+	pub version: SocketVersion,
+}
+
+impl Default for SocketVariants {
+	fn default() -> Self {
+		Self {
+			source_chain: Bytes::default(),
+			receiver: Address::default(),
+			max_fee: U256::default(),
+			data: Bytes::default(),
+			version: SocketVersion::V1,
 		}
 	}
 }

--- a/primitives/src/periodic.rs
+++ b/primitives/src/periodic.rs
@@ -15,14 +15,15 @@ use crate::{eth::ChainID, socket::SocketMessage};
 /// The channel message that contains a rollbackable socket message.
 pub struct RollbackableMessage {
 	/// The timestamp that this relayer has tried to process the socket event.
-	pub timestamp: U256,
+	/// If time passed as long as `ROLLBACK_CHECK_MINIMUM_INTERVAL`, this request will be rollbacked.
+	pub timeout_started_at: U256,
 	/// The rollbackable socket message. This will be either `Inbound::Requested` or `Outbound::Accepted`.
 	pub socket_msg: SocketMessage,
 }
 
 impl RollbackableMessage {
 	pub fn new(timestamp: U256, socket_msg: SocketMessage) -> Self {
-		Self { timestamp, socket_msg }
+		Self { timeout_started_at: timestamp, socket_msg }
 	}
 }
 

--- a/primitives/src/periodic.rs
+++ b/primitives/src/periodic.rs
@@ -11,43 +11,6 @@ use tokio::{
 
 use crate::{eth::ChainID, socket::SocketMessage};
 
-#[derive(Clone, Debug)]
-/// The channel message that contains a rollbackable socket message.
-pub struct RollbackableMessage {
-	/// The timestamp that this relayer has tried to process the socket event.
-	/// If time passed as long as `ROLLBACK_CHECK_MINIMUM_INTERVAL`, this request will be rollbacked.
-	pub timeout_started_at: U256,
-	/// The rollbackable socket message. This will be either `Inbound::Requested` or `Outbound::Accepted`.
-	pub socket_msg: SocketMessage,
-}
-
-impl RollbackableMessage {
-	pub fn new(timestamp: U256, socket_msg: SocketMessage) -> Self {
-		Self { timeout_started_at: timestamp, socket_msg }
-	}
-}
-
-/// The primitive sequence ID of a single socket request.
-pub type RawRequestID = u128;
-
-/// The channel message sender for rollbackable socket messages.
-pub struct RollbackSender {
-	/// The unique chain ID for this sender.
-	pub id: ChainID,
-	/// The channel message sender.
-	pub sender: UnboundedSender<SocketMessage>,
-}
-
-impl RollbackSender {
-	pub fn new(id: ChainID, sender: UnboundedSender<SocketMessage>) -> Self {
-		Self { id, sender }
-	}
-
-	pub fn send(&self, message: SocketMessage) -> Result<(), SendError<SocketMessage>> {
-		self.sender.send(message)
-	}
-}
-
 /// The schedule definition for oracle price feeding. This will trigger on every 5th minute.
 pub const PRICE_FEEDER_SCHEDULE: &str = "0 */5 * * * * *";
 
@@ -60,8 +23,8 @@ pub const HEARTBEAT_SCHEDULE: &str = "0 * * * * * *";
 /// The scedule definition for rollback checks. This will trigger on every minute.
 pub const ROLLBACK_CHECK_SCHEDULE: &str = "0 * * * * * *";
 
-/// The minimum interval that should be passed in order to handle rollback checks. (=5 minutes)
-pub const ROLLBACK_CHECK_MINIMUM_INTERVAL: u32 = 5 * 60 * 1000;
+/// The minimum interval that should be passed in order to handle rollback checks. (=3 minutes)
+pub const ROLLBACK_CHECK_MINIMUM_INTERVAL: u32 = 3 * 60;
 
 #[async_trait]
 pub trait PeriodicWorker {
@@ -108,4 +71,41 @@ pub trait PriceFetcher {
 
 	/// Get all prices of support coin/token.
 	async fn get_tickers(&self) -> Result<BTreeMap<String, PriceResponse>, Error>;
+}
+
+#[derive(Clone, Debug)]
+/// The channel message that contains a rollbackable socket message.
+pub struct RollbackableMessage {
+	/// The timestamp that this relayer has tried to process the socket event.
+	/// If time passed as long as `ROLLBACK_CHECK_MINIMUM_INTERVAL`, this request will be rollbacked.
+	pub timeout_started_at: U256,
+	/// The rollbackable socket message. This will be either `Inbound::Requested` or `Outbound::Accepted`.
+	pub socket_msg: SocketMessage,
+}
+
+impl RollbackableMessage {
+	pub fn new(timestamp: U256, socket_msg: SocketMessage) -> Self {
+		Self { timeout_started_at: timestamp, socket_msg }
+	}
+}
+
+/// The primitive sequence ID of a single socket request.
+pub type RawRequestID = u128;
+
+/// The channel message sender for rollbackable socket messages.
+pub struct RollbackSender {
+	/// The unique chain ID for this sender.
+	pub id: ChainID,
+	/// The channel message sender.
+	pub sender: UnboundedSender<SocketMessage>,
+}
+
+impl RollbackSender {
+	pub fn new(id: ChainID, sender: UnboundedSender<SocketMessage>) -> Self {
+		Self { id, sender }
+	}
+
+	pub fn send(&self, message: SocketMessage) -> Result<(), SendError<SocketMessage>> {
+		self.sender.send(message)
+	}
 }

--- a/primitives/src/periodic.rs
+++ b/primitives/src/periodic.rs
@@ -17,7 +17,7 @@ pub const PRICE_FEEDER_SCHEDULE: &str = "0 */5 * * * * *";
 /// The schedule definition for roundup emissions. This will trigger on every 15th second.
 pub const ROUNDUP_EMITTER_SCHEDULE: &str = "*/15 * * * * * *";
 
-/// The scedule definition for heartbeats. This will trigger on every minute.
+/// The schedule definition for heartbeats. This will trigger on every minute.
 pub const HEARTBEAT_SCHEDULE: &str = "0 * * * * * *";
 
 /// The scedule definition for rollback checks. This will trigger on every minute.

--- a/primitives/src/periodic.rs
+++ b/primitives/src/periodic.rs
@@ -20,7 +20,7 @@ pub const ROUNDUP_EMITTER_SCHEDULE: &str = "*/15 * * * * * *";
 /// The schedule definition for heartbeats. This will trigger on every minute.
 pub const HEARTBEAT_SCHEDULE: &str = "0 * * * * * *";
 
-/// The scedule definition for rollback checks. This will trigger on every minute.
+/// The schedule definition for rollback checks. This will trigger on every minute.
 pub const ROLLBACK_CHECK_SCHEDULE: &str = "0 * * * * * *";
 
 /// The minimum interval that should be passed in order to handle rollback checks. (=3 minutes)

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -47,7 +47,7 @@ fn construct_periodics(
 	let event_senders = &relayer_deps.event_senders;
 
 	let mut rollback_handlers = vec![];
-	let mut rollback_senders = vec![];
+	let mut rollback_senders = BTreeMap::new();
 
 	// initialize the heartbeat sender
 	let heartbeat_sender = HeartbeatSender::new(event_senders.clone(), clients.clone());
@@ -67,7 +67,10 @@ fn construct_periodics(
 		let (rollback_handler, rollback_sender) =
 			SocketRollbackHandler::new(event_sender.clone(), clients.clone());
 		rollback_handlers.push(rollback_handler);
-		rollback_senders.push(Arc::new(RollbackSender::new(event_sender.id, rollback_sender)));
+		rollback_senders.insert(
+			event_sender.id,
+			Arc::new(RollbackSender::new(event_sender.id, rollback_sender)),
+		);
 	});
 
 	PeriodicDeps {
@@ -473,7 +476,7 @@ struct PeriodicDeps {
 	/// The `SocketRollbackHandler`'s for each specified chain.
 	rollback_handlers: Vec<SocketRollbackHandler<Http>>,
 	/// The `RollbackSender`'s for each specified chain.
-	rollback_senders: Vec<Arc<RollbackSender>>,
+	rollback_senders: BTreeMap<ChainID, Arc<RollbackSender>>,
 }
 
 struct HandlerDeps {


### PR DESCRIPTION
## Description

### 1. Implement `SocketRollbackHandler`
- 목적
  - 특정 요청이 정해진 시간 내에 처리되지 못한 경우, 해당 요청이 롤백될 수 있도록 처리하는 periodics 컴포넌트. 이때 처리되지 못했다는 의미는 해당 요청에 대해 `Socket::Executed` 혹은 `Socket::Reverted` 이벤트가 emit되지 않은 상태를 의미함
- 구동 방식
  - 체인 당 하나씩 생성됨. 즉, `SocketRollbackHandler` struct 내에 존재하는 필드 중, `client`와 `event_sender`는 동일한 체인을 바라봄.
  - `SocketRelayHandler`는 앞으로 executable (`Inbound::Requested` 혹은 `Outbound::Accepted`) 단계에서는 해당 Socket message를 `SocketRollbackHandler`의 채널로 전송함
  - `SocketRollbackHandler`는 periodics 이므로 매분마다 자신의 채널에 쌓인 Socket message를 꺼내 로컬 변수인 `rollback_msgs`에 `RollbackableMessage` 형태로 저장함.
    - `RollbackableMessage`는 struct로 두가지 변수를 가지고 있음. 전달 받은 Socket message와 timestamp (`timeout_started_at`)를 가지고 있는데, timestamp는 현재 릴레이어가 message를 전달 받을 당시의 `client`가 바라보고 있는 가장 높은 블록의 timestamp를 저장하게 됨.
    - 매 interval마다 rollback_msgs에 쌓인 `RollbackableMessage` 들을 조회하여, execution이 되었는지 혹은 timeout이 발생했는지 검사함. 만약, timeout이 발생했고 execution도 안되었으면 rollback을 시도함

### 2. Implement `ExecutionFilter`
- 목적
  - Executor → Receiver 호출에 대한 실패를 사전에 방지 하기 위한 필터링 역할
- 구동 방식
  - `SocketRelayHandler`는 앞으로 executable (`Inbound::Requested` 혹은 `Outbound::Accepted`) 단계에서는 필터링을 하기 위해 바로 `EventChannel`로 전송하지 않고, `ExecutionFilter` task를 spawn하는 것으로 변경됨
  - `ExecutionFilter` task는 Executor → Receiver 호출에 대한 사전적으로 실행 가능 여부를 파악함 (by gas estimation)
  - Gas estimation에 대한 실패 가능성이 있으니 별도의 task로 분류함 (retry로 인한 병목을 없애기 위해)
  - 실행이 가능한 요청이라면 그제서야 `EventChannel`로 전송함

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
