### PR TITLE
CCCP-382: feature: Arbitrum `eth_syncing` response format

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ serde = "1.0.188"
 serde_json = "1.0.107"
 
 hex = "0.4.3"
-ethers = "2.0.10"
+ethers = { git = "https://github.com/bifrost-platform/ethers-rs", tag = "ethers-v2.0.10-arbitrum-support" }
 k256 = "0.13.1"
 sha3 = "0.10.8"
 

--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -186,7 +186,7 @@ impl<T: JsonRpcClient> EventManager<T> {
 				SyncingStatus::IsSyncing(status) => {
 					log::info!(
 						target: &self.client.get_chain_name(),
-						"-[{}] ⚙️  Syncing #{:?}, Highest: #{:?}",
+						"-[{}] ⚙️  Syncing: #{:?}, Highest: #{:?}",
 						sub_display_format(SUB_LOG_TARGET),
 						status.current_block,
 						status.highest_block,
@@ -195,7 +195,7 @@ impl<T: JsonRpcClient> EventManager<T> {
 				SyncingStatus::IsArbitrumSyncing(status) => {
 					log::info!(
 						target: &self.client.get_chain_name(),
-						"-[{}] ⚙️  Syncing #{:?}, Highest: #{:?}",
+						"-[{}] ⚙️  Processed batch: #{:?}, Last batch: #{:?}",
 						sub_display_format(SUB_LOG_TARGET),
 						status.batch_processed,
 						status.batch_seen


### PR DESCRIPTION
## Description

* Arbitrum `eth_syncing` 응답 포맷에 대응

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
