### PR TITLE
CCCP-386, fix: simplify outbound handler

### DIFF
--- a/client/src/btc/handlers/mod.rs
+++ b/client/src/btc/handlers/mod.rs
@@ -18,13 +18,13 @@ use br_primitives::{
 	bootstrap::BootstrapSharedData,
 	eth::{BootstrapState, GasCoefficient},
 	tx::{
-		BitcoinRelayMetadata, TxRequest, TxRequestMessage, TxRequestMetadata, TxRequestSender,
-		XtRequest, XtRequestMessage, XtRequestMetadata, XtRequestSender,
+		TxRequest, TxRequestMessage, TxRequestMetadata, TxRequestSender, XtRequest,
+		XtRequestMessage, XtRequestMetadata, XtRequestSender,
 	},
 	utils::sub_display_format,
 };
-use ethers::{prelude::TransactionRequest, providers::JsonRpcClient, types::Bytes};
-use std::{collections::BTreeSet, sync::Arc};
+use ethers::{prelude::TransactionRequest, providers::JsonRpcClient};
+use std::sync::Arc;
 
 use super::block::EventMessage;
 
@@ -96,12 +96,12 @@ pub trait TxRequester<T: JsonRpcClient> {
 	async fn request_send_transaction(
 		&self,
 		tx_request: TransactionRequest,
-		metadata: BitcoinRelayMetadata,
+		metadata: TxRequestMetadata,
 		sub_log_target: &str,
 	) {
 		match self.tx_request_sender().send(TxRequestMessage::new(
 			TxRequest::Legacy(tx_request),
-			TxRequestMetadata::BitcoinSocketRelay(metadata.clone()),
+			metadata.clone(),
 			true,
 			false,
 			GasCoefficient::Mid,
@@ -142,12 +142,7 @@ pub trait TxRequester<T: JsonRpcClient> {
 pub trait Handler {
 	async fn run(&mut self);
 
-	async fn process_event(
-		&self,
-		event_tx: Event,
-		_processed: &mut BTreeSet<Bytes>,
-		is_bootstrap: bool,
-	);
+	async fn process_event(&self, event_tx: Event);
 
 	fn is_target_event(&self, event_type: EventType) -> bool;
 }

--- a/client/src/btc/handlers/psbt_signer.rs
+++ b/client/src/btc/handlers/psbt_signer.rs
@@ -5,7 +5,6 @@ use br_primitives::{
 };
 use ethers::{providers::JsonRpcClient, types::Bytes};
 use miniscript::bitcoin::Psbt;
-use std::collections::BTreeSet;
 use tokio::sync::broadcast::Receiver;
 use tokio_stream::StreamExt;
 
@@ -166,7 +165,9 @@ impl<T: JsonRpcClient> Handler for PsbtSigner<T> {
 		}
 	}
 
-	async fn process_event(&self, _event_tx: Event, _: &mut BTreeSet<Bytes>, _is_bootstrap: bool) {}
+	async fn process_event(&self, _event_tx: Event) {
+		unreachable!("unimplemented")
+	}
 
 	#[inline]
 	fn is_target_event(&self, event_type: EventType) -> bool {


### PR DESCRIPTION
## Description

### Changes
- tx의 output 단위가 아닌 tx 단위로 아웃바운드 처리

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
