### PR TITLE
CCCP-413, fix: replace waitfornewblock

### DIFF
--- a/client/src/btc/block.rs
+++ b/client/src/btc/block.rs
@@ -104,6 +104,8 @@ pub struct BlockManager<T> {
 	block_confirmations: u64,
 	/// The block that is waiting for confirmations.
 	waiting_block: u64,
+	/// The `getblockcount` request interval in milliseconds.
+	call_interval: u64,
 	/// The bootstrap shared data.
 	bootstrap_shared_data: Arc<BootstrapSharedData>,
 	/// The bootstrap offset in blocks.
@@ -147,6 +149,7 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 		bfc_client: Arc<EthClient<T>>,
 		_pending_outbounds: PendingOutboundPool,
 		bootstrap_shared_data: Arc<BootstrapSharedData>,
+		call_interval: u64,
 	) -> Self {
 		let (sender, _receiver) = broadcast::channel(512);
 
@@ -165,6 +168,7 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 			sender,
 			block_confirmations: 0,
 			waiting_block: 0,
+			call_interval,
 			bootstrap_shared_data,
 			bootstrap_offset,
 			_pending_outbounds,
@@ -198,7 +202,7 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 				}
 			}
 
-			self.wait_for_new_block(0).await.unwrap();
+			sleep(Duration::from_millis(self.call_interval)).await;
 		}
 	}
 

--- a/configs/config.testnet.yaml
+++ b/configs/config.testnet.yaml
@@ -6,8 +6,9 @@ system:
 
 btc_provider:
   id: 10001
-  provider: "<YOUR_BITCOIN_RPC_ENDPOINT>"
   chain: "test"
+  provider: "<YOUR_BITCOIN_RPC_ENDPOINT>"
+  call_interval: 10000
 
 evm_providers:
   - name: "bifrost-testnet"

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -135,6 +135,8 @@ pub struct BTCProvider {
 	pub id: u32,
 	/// The Bitcoin provider URL.
 	pub provider: String,
+	/// The time interval(ms) used when to request a new block
+	pub call_interval: u64,
 	/// The chain network. (Allowed values: `main`, `test`, `signet`, `regtest`)
 	pub chain: String,
 	/// Optional. The provider username credential.

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -322,6 +322,7 @@ fn construct_btc_deps(
 		bfc_client.clone(),
 		pending_outbounds.clone(),
 		bootstrap_shared_data.clone(),
+		config.relayer_config.btc_provider.call_interval.clone(),
 	);
 	let inbound = InboundHandler::new(
 		bfc_client.clone(),


### PR DESCRIPTION
## Description

- Replace `waitfornewblock` to interval-based `getblockcount`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
