### PR TITLE
CCCP-417, fix: handle zero block confirmations correctly

### DIFF
--- a/client/src/btc/block.rs
+++ b/client/src/btc/block.rs
@@ -175,13 +175,13 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 
 	/// Starts the block manager.
 	pub async fn run(&mut self) {
-		self.waiting_block = self.get_block_count().await.unwrap();
+		self.waiting_block = self.get_block_count().await.unwrap().saturating_add(1);
 
 		log::info!(
 			target: LOG_TARGET,
 			"-[{}] 💤 Idle, best: #{:?}",
 			sub_display_format(SUB_LOG_TARGET),
-			self.waiting_block
+			self.waiting_block.saturating_sub(1)
 		);
 
 		loop {
@@ -259,6 +259,9 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 	/// Verifies if the stored waiting block has waited enough.
 	#[inline]
 	fn is_block_confirmed(&self, latest_block_num: u64) -> bool {
+		if self.waiting_block > latest_block_num {
+			return false;
+		}
 		latest_block_num.saturating_sub(self.waiting_block) >= self.block_confirmations
 	}
 

--- a/client/src/btc/block.rs
+++ b/client/src/btc/block.rs
@@ -175,13 +175,14 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 
 	/// Starts the block manager.
 	pub async fn run(&mut self) {
-		self.waiting_block = self.get_block_count().await.unwrap().saturating_add(1);
+		let latest_block = self.get_block_count().await.unwrap();
+		self.waiting_block = latest_block.saturating_add(1);
 
 		log::info!(
 			target: LOG_TARGET,
 			"-[{}] 💤 Idle, best: #{:?}",
 			sub_display_format(SUB_LOG_TARGET),
-			self.waiting_block.saturating_sub(1)
+			latest_block
 		);
 
 		loop {


### PR DESCRIPTION
## Description

- zero block confirmation 상태에서 `is_block_confirmed()` 메소드에서 참으로 간주하지 못하도록 수정

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
