### PR TITLE
CCCP-422, fix: remove unused `.clone()`

### DIFF
--- a/client/src/btc/block.rs
+++ b/client/src/btc/block.rs
@@ -326,13 +326,10 @@ impl<T: JsonRpcClient + 'static> BlockManager<T> {
 		let mut stream = tokio_stream::iter(vouts.iter());
 		while let Some(vout) = stream.next().await {
 			if let Some(address) = vout.script_pub_key.address.clone() {
+				// address can only be contained in either one set.
 				if vault_set.contains(&address) {
-					inbound_events.push(Event {
-						txid,
-						index: vout.n,
-						address: address.clone(),
-						amount: vout.value,
-					});
+					inbound_events.push(Event { txid, index: vout.n, address, amount: vout.value });
+					continue;
 				}
 				if refund_set.contains(&address) {
 					outbound_events.push(Event {


### PR DESCRIPTION
## Description

- remove `.clone()`
- add `continue`

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
