### PR TITLE
[CCCP-506] allow multiple signers for `signer_config` field

### DIFF
--- a/client/src/btc/handlers/inbound.rs
+++ b/client/src/btc/handlers/inbound.rs
@@ -130,7 +130,7 @@ where
 
 		Ok(self
 			.bitcoin_socket()
-			.isRelayerVoted(hash_key, self.bfc_client.address())
+			.isRelayerVoted(hash_key, self.bfc_client.address().await)
 			.call()
 			.await?
 			._0)

--- a/client/src/btc/handlers/mod.rs
+++ b/client/src/btc/handlers/mod.rs
@@ -38,7 +38,7 @@ where
 
 	fn bfc_client(&self) -> Arc<EthClient<F, P>>;
 
-	fn request_send_transaction(
+	async fn request_send_transaction(
 		&self,
 		xt_request: XtRequest,
 		metadata: XtRequestMetadata,
@@ -79,7 +79,7 @@ where
 				let log_msg = format!(
 					"-[{}]-[{}] ❗️ Failed to send unsigned transaction: {}, Error: {}",
 					sub_display_format(sub_log_target),
-					self.bfc_client().address(),
+					self.bfc_client().address().await,
 					metadata,
 					error
 				);

--- a/client/src/eth/handlers/roundup_relay_handler.rs
+++ b/client/src/eth/handlers/roundup_relay_handler.rs
@@ -229,7 +229,7 @@ where
 	async fn is_selected_relayer(&self, round: U256) -> Result<bool> {
 		let relayer_manager = self.client.protocol_contracts.relayer_manager.as_ref().unwrap();
 		Ok(relayer_manager
-			.is_previous_selected_relayer(round, self.client.address(), true)
+			.is_previous_selected_relayer(round, self.client.address().await, true)
 			.call()
 			.await?
 			._0)

--- a/client/src/eth/handlers/socket_relay_handler.rs
+++ b/client/src/eth/handlers/socket_relay_handler.rs
@@ -127,7 +127,7 @@ where
 				"[{}]-[{}]-[{}] Unknown error while decoding socket event: {:?}",
 				&self.client.get_chain_name(),
 				SUB_LOG_TARGET,
-				self.client.address(),
+				self.client.address().await,
 				error,
 			),
 		}
@@ -214,7 +214,7 @@ where
 				"[{}]-[{}]-[{}] Unknown socket event status received: {:?}",
 				&self.client.get_chain_name(),
 				SUB_LOG_TARGET,
-				self.client.address(),
+				self.client.address().await,
 				status
 			),
 		};
@@ -241,7 +241,7 @@ where
 				"[{}]-[{}]-[{}] Unknown socket event status received: {:?}",
 				&self.client.get_chain_name(),
 				SUB_LOG_TARGET,
-				self.client.address(),
+				self.client.address().await,
 				status
 			),
 		};
@@ -414,7 +414,7 @@ where
 		let relayer_manager =
 			self.bifrost_client.protocol_contracts.relayer_manager.as_ref().unwrap();
 		let res = relayer_manager
-			.is_previous_selected_relayer(*round, self.client.address(), false)
+			.is_previous_selected_relayer(*round, self.client.address().await, false)
 			.call()
 			.await?
 			._0;
@@ -431,7 +431,7 @@ where
 	) {
 		if let Some(client) = self.system_clients.get(&chain_id) {
 			if self.is_executable(metadata.is_inbound, metadata.status) {
-				self.send_rollbackable_request(chain_id, metadata.clone(), socket_msg);
+				self.send_rollbackable_request(chain_id, metadata.clone(), socket_msg).await;
 			}
 
 			let metadata = TxRequestMetadata::SocketRelay(metadata);
@@ -448,7 +448,7 @@ where
 
 	/// Sends a rollbackable socket message to the rollback channel.
 	/// The received message will be handled when the interval has been reached.
-	fn send_rollbackable_request(
+	async fn send_rollbackable_request(
 		&self,
 		chain_id: ChainId,
 		metadata: SocketRelayMetadata,
@@ -466,7 +466,7 @@ where
 					let msg = format!(
 						"-[{}]-[{}] ❗️ Failed to store rollbackable socket message: {}, Error: {}",
 						sub_display_format(SUB_LOG_TARGET),
-						self.client.address(),
+						self.client.address().await,
 						metadata,
 						error
 					);

--- a/client/src/eth/mod.rs
+++ b/client/src/eth/mod.rs
@@ -376,7 +376,6 @@ where
 		}
 
 		let mut this_request = request.clone();
-		this_request.from = Some(self.address().await);
 		self.fill_gas(&mut this_request).await?;
 
 		let pending = match self.send_transaction(WithOtherFields::new(this_request)).await {
@@ -482,7 +481,6 @@ pub fn send_transaction<F, P>(
 			return;
 		}
 
-		request.from = Some(client.address().await);
 		match client.send_transaction(WithOtherFields::new(request.clone())).await {
 			Ok(pending) => {
 				log::info!(

--- a/client/src/eth/mod.rs
+++ b/client/src/eth/mod.rs
@@ -134,14 +134,21 @@ where
 			},
 		};
 
-		match self.signers().iter().find(|s| relayers.contains(s)) {
-			Some(selected) => {
-				self.set_address(*selected).await;
-			},
-			None => {
-				self.set_address(Address::default()).await;
-			},
+		let matched = match self.signers().iter().find(|s| relayers.contains(s)) {
+			Some(selected) => *selected,
+			None => Address::default(),
 		};
+
+		let before_update = self.address().await;
+		if before_update != matched {
+			log::info!(
+				target: SUB_LOG_TARGET,
+				"👤 Relayer updated: {} -> {}",
+				before_update,
+				matched
+			);
+			self.set_address(matched).await;
+		}
 	}
 
 	/// Get the chain name.

--- a/client/src/substrate/traits.rs
+++ b/client/src/substrate/traits.rs
@@ -57,7 +57,7 @@ where
 		let log_msg = format!(
 			"-[{}]-[{}] ♻️  Unknown error while requesting a transaction request: {}, Retries left: {:?}, Error: {}",
 			sub_display_format(sub_target),
-			self.get_bfc_client().address(),
+			self.get_bfc_client().address().await,
 			msg.metadata,
 			msg.retries_remaining - 1,
 			error_str,
@@ -79,7 +79,7 @@ where
 		let log_msg = format!(
 			"-[{}]-[{}] ♻️  Unknown error while creating a tx request: {}, Retries left: {:?}, Error: {}",
 			sub_display_format(sub_target),
-			self.get_bfc_client().address(),
+			self.get_bfc_client().address().await,
 			msg.metadata,
 			msg.retries_remaining - 1,
 			error,

--- a/configs/config.mainnet.yaml
+++ b/configs/config.mainnet.yaml
@@ -4,8 +4,8 @@ system:
 signer_config:
   # Two parameters below are optional, but one of them must be provided.
   # `kms_key_id` has higher priority than `private_key`.
-  kms_key_id: "<YOUR_KMS_KEY_ID_FOR_SIGNER>"
-  private_key: "<YOUR_RELAYER_PRIVATE_KEY>"
+  - kms_key_id: "<YOUR_KMS_KEY_ID_FOR_SIGNER>"
+    private_key: "<YOUR_RELAYER_PRIVATE_KEY>"
 
 keystore_config:
   path: "<YOUR_KEYSTORE_PATH>"

--- a/configs/config.testnet.yaml
+++ b/configs/config.testnet.yaml
@@ -4,8 +4,8 @@ system:
 signer_config:
   # Two parameters below are optional, but one of them must be provided.
   # `kms_key_id` has higher priority than `private_key`.
-  kms_key_id: "<YOUR_KMS_KEY_ID_FOR_SIGNER>"
-  private_key: "<YOUR_RELAYER_PRIVATE_KEY>"
+  - kms_key_id: "<YOUR_KMS_KEY_ID_FOR_SIGNER>"
+    private_key: "<YOUR_RELAYER_PRIVATE_KEY>"
 
 keystore_config:
   path: "<YOUR_KEYSTORE_PATH>"

--- a/periodic/src/bitcoin_rollback_verifier.rs
+++ b/periodic/src/bitcoin_rollback_verifier.rs
@@ -191,7 +191,7 @@ where
 					}
 
 					// check if already submitted
-					if let Some(vote) = request.votes.get(&self.bfc_client.address()) {
+					if let Some(vote) = request.votes.get(&self.bfc_client.address().await) {
 						if *vote == is_approved {
 							continue;
 						}
@@ -203,7 +203,8 @@ where
 						call,
 						XtRequestMetadata::SubmitRollbackPoll(metadata),
 						SUB_LOG_TARGET,
-					);
+					)
+					.await;
 				}
 			}
 		}
@@ -265,7 +266,7 @@ where
 		is_approved: bool,
 	) -> Result<(RollbackPollMessage<AccountId20>, EthereumSignature)> {
 		let msg = RollbackPollMessage {
-			authority_id: AccountId20(self.bfc_client.address().0.0),
+			authority_id: AccountId20(self.bfc_client.address().await.0.0),
 			txid: H256::from(txid.0),
 			is_approved,
 		};

--- a/periodic/src/heartbeat_sender.rs
+++ b/periodic/src/heartbeat_sender.rs
@@ -45,7 +45,7 @@ where
 
 	async fn run(&mut self) -> Result<()> {
 		loop {
-			let address = self.client.address();
+			let address = self.client.address().await;
 
 			let relayer_manager = self.client.protocol_contracts.relayer_manager.as_ref().unwrap();
 			let is_selected = relayer_manager.is_selected_relayer(address, false).call().await?._0;

--- a/periodic/src/price_feeder.rs
+++ b/periodic/src/price_feeder.rs
@@ -160,7 +160,7 @@ where
 				let log_msg = format!(
 					"-[{}]-[{}] ❗️ Failed to fetch price feed data from secondary sources. First off, skip this feeding.",
 					sub_display_format(SUB_LOG_TARGET),
-					self.client.address()
+					self.client.address().await
 				);
 				log::error!(target: &self.client.get_chain_name(), "{log_msg}");
 				sentry::capture_message(

--- a/periodic/src/psbt_signer.rs
+++ b/periodic/src/psbt_signer.rs
@@ -80,7 +80,7 @@ where
 	/// Verify whether the current relayer is an executive.
 	async fn is_relay_executive(&self) -> Result<bool> {
 		let relay_exec = self.client.protocol_contracts.relay_executive.as_ref().unwrap();
-		Ok(relay_exec.is_member(self.client.address()).call().await?._0)
+		Ok(relay_exec.is_member(self.client.address().await).call().await?._0)
 	}
 
 	/// Build the payload for the unsigned transaction. (`submit_signed_psbt()`)
@@ -132,7 +132,7 @@ where
 			}
 
 			let msg = SignedPsbtMessage {
-				authority_id: AccountId20(self.client.address().0.0),
+				authority_id: AccountId20(self.client.address().await.0.0),
 				unsigned_psbt: unsigned_psbt.serialize(),
 				signed_psbt: signed_psbt.clone(),
 			};
@@ -190,7 +190,7 @@ where
 	async fn is_signed_psbt_submitted(&self, txid: B256, psbt: Vec<u8>) -> Result<bool> {
 		let socket_queue = self.client.protocol_contracts.socket_queue.as_ref().unwrap();
 		let res = socket_queue
-			.is_signed_psbt_submitted(txid, Bytes::from(psbt), self.client.address())
+			.is_signed_psbt_submitted(txid, Bytes::from(psbt), self.client.address().await)
 			.call()
 			.await?
 			._0;
@@ -248,7 +248,8 @@ where
 							call,
 							XtRequestMetadata::SubmitSignedPsbt(metadata),
 							SUB_LOG_TARGET,
-						);
+						)
+						.await;
 					}
 				}
 			}

--- a/periodic/src/roundup_emitter.rs
+++ b/periodic/src/roundup_emitter.rs
@@ -84,7 +84,7 @@ where
 				);
 
 				let new_relayers = self.fetch_validator_list(latest_round).await?;
-				self.update_account(&new_relayers).await;
+				self.client.update_default_address(Some(&new_relayers)).await;
 
 				if !self.is_selected_relayer(latest_round).await? {
 					continue;
@@ -122,10 +122,6 @@ where
 			handle,
 			debug_mode,
 		}
-	}
-
-	async fn update_account(&self, new_relayers: &[Address]) {
-		// TODO: Implement this
 	}
 
 	/// Check relayer has selected in previous round

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -40,7 +40,7 @@ pub struct RelayerConfig {
 	/// System config
 	pub system: Option<SystemConfig>,
 	/// Signer config
-	pub signer_config: SignerConfig,
+	pub signer_config: Vec<SignerConfig>,
 	/// Keystore config
 	pub keystore_config: Option<KeystoreConfig>,
 	/// EVM configs

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -1,14 +1,14 @@
-use std::{str::FromStr, sync::Arc};
-
 use alloy::{
 	network::AnyNetwork,
-	primitives::{Address, ChainId},
+	primitives::{Address, ChainId, map::AddressHashMap},
 	providers::{
 		Provider, WalletProvider,
 		fillers::{FillProvider, TxFiller},
 	},
 	rpc::types::TransactionRequest,
+	signers::Signer,
 };
+use std::{str::FromStr, sync::Arc};
 use url::Url;
 
 use crate::{
@@ -28,6 +28,19 @@ use crate::{
 		socket_queue::{SocketQueueContract, SocketQueueInstance},
 	},
 };
+
+#[derive(Clone, Default)]
+pub struct Signers(AddressHashMap<Arc<dyn Signer + Send + Sync>>);
+
+impl Signers {
+	pub fn get_signer(&self, address: &Address) -> Option<Arc<dyn Signer + Send + Sync>> {
+		self.0.get(address).cloned()
+	}
+
+	pub fn register_signer(&mut self, signer: Arc<dyn Signer + Send + Sync>) {
+		self.0.insert(signer.address(), signer);
+	}
+}
 
 #[derive(Clone)]
 /// The metadata of the EVM provider.

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -40,6 +40,10 @@ impl Signers {
 	pub fn register_signer(&mut self, signer: Arc<dyn Signer + Send + Sync>) {
 		self.0.insert(signer.address(), signer);
 	}
+
+	pub fn signers_address(&self) -> Vec<Address> {
+		self.0.keys().cloned().collect()
+	}
 }
 
 #[derive(Clone)]

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -153,13 +153,6 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 		// initialize default address to selected account
 		if is_native {
 			client.update_default_address(None).await;
-
-			log::info!(
-				target: LOG_TARGET,
-				"-[{}] 👤 Provided signers: {:?}",
-				sub_display_format(SUB_LOG_TARGET),
-				client.signers()
-			);
 		}
 
 		clients.insert(evm_provider.id, client);
@@ -601,6 +594,12 @@ where
 	F: TxFiller<AnyNetwork> + WalletProvider<AnyNetwork>,
 	P: Provider<AnyNetwork>,
 {
+	log::info!(
+		target: LOG_TARGET,
+		"-[{}] 👤 Provided signers: {:?}",
+		sub_display_format(SUB_LOG_TARGET),
+		manager_deps.bifrost_client.signers()
+	);
 	log::info!(
 		target: LOG_TARGET,
 		"-[{}] 🔨 Relay Targets: {}",

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -596,12 +596,6 @@ where
 {
 	log::info!(
 		target: LOG_TARGET,
-		"-[{}] 👤 Relayer: {:?}",
-		sub_display_format(SUB_LOG_TARGET),
-		manager_deps.bifrost_client.address().await
-	);
-	log::info!(
-		target: LOG_TARGET,
 		"-[{}] 🔨 Relay Targets: {}",
 		sub_display_format(SUB_LOG_TARGET),
 		manager_deps

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -150,9 +150,13 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 			),
 		));
 
+		// initialize default address to selected account
+		if is_native {
+			client.update_default_address(None).await;
+		}
+
 		clients.insert(evm_provider.id, client);
 	}
-	// TODO: initialize default address
 
 	let bootstrap_shared_data = BootstrapSharedData::new(&config);
 

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -6,6 +6,7 @@ use std::{
 	time::Duration,
 };
 
+use alloy::primitives::Address;
 use alloy::{
 	network::{AnyNetwork, EthereumWallet},
 	providers::{
@@ -21,6 +22,11 @@ use miniscript::bitcoin::Network;
 use sc_service::{Error as ServiceError, TaskManager, config::PrometheusConfig};
 use tokio::sync::RwLock;
 
+use crate::{
+	cli::{LOG_TARGET, SUB_LOG_TARGET},
+	service_deps::{BtcDeps, FullDeps, HandlerDeps, ManagerDeps, PeriodicDeps, SubstrateDeps},
+	verification::assert_configuration_validity,
+};
 use br_client::{
 	btc::{
 		handlers::Handler as _,
@@ -29,6 +35,7 @@ use br_client::{
 	eth::{EthClient, retry::RetryBackoffLayer, traits::Handler as _},
 };
 use br_periodic::traits::PeriodicWorker;
+use br_primitives::eth::Signers;
 use br_primitives::{
 	bootstrap::BootstrapSharedData,
 	cli::{Configuration, HandlerType},
@@ -43,12 +50,6 @@ use br_primitives::{
 	eth::{AggregatorContracts, ProtocolContracts, ProviderMetadata},
 	substrate::MigrationSequence,
 	utils::sub_display_format,
-};
-
-use crate::{
-	cli::{LOG_TARGET, SUB_LOG_TARGET},
-	service_deps::{BtcDeps, FullDeps, HandlerDeps, ManagerDeps, PeriodicDeps, SubstrateDeps},
-	verification::assert_configuration_validity,
 };
 
 /// Starts the relayer service.
@@ -66,7 +67,7 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 	let mut clients = BTreeMap::new();
 
 	// Initialize AWS client once if needed
-	let aws_client = if signer_config.kms_key_id.is_some()
+	let aws_client = if signer_config.iter().any(|s| s.kms_key_id.is_some())
 		|| keystore_config.as_ref().and_then(|c| c.kms_key_id.as_ref()).is_some()
 	{
 		Some(aws_sdk_kms::Client::new(
@@ -76,6 +77,33 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 		None
 	};
 
+	let mut wallet = EthereumWallet::default();
+	let mut signers = Signers::default();
+	for s in signer_config {
+		if let Some(key_id) = &s.kms_key_id {
+			let signer = Arc::new(
+				AwsSigner::new(
+					aws_client.as_ref().unwrap().clone(),
+					key_id.clone(),
+					btc_provider.id.into(),
+				)
+				.await
+				.expect(KMS_INITIALIZATION_ERROR),
+			);
+			wallet.register_signer(signer.clone());
+			signers.register_signer(signer);
+		} else {
+			let mut signer =
+				PrivateKeySigner::from_str(&s.private_key.clone().expect(INVALID_PRIVATE_KEY))
+					.expect(INVALID_PRIVATE_KEY);
+			signer.set_chain_id(Some(btc_provider.id));
+			let signer = Arc::new(signer);
+			wallet.register_signer(signer.clone());
+			signers.register_signer(signer);
+		}
+	}
+
+	let default_address = Arc::new(RwLock::new(Address::default()));
 	for evm_provider in evm_providers {
 		let url: Url = evm_provider.provider.clone().parse().expect(INVALID_PROVIDER_URL);
 		let is_native = evm_provider.is_native.unwrap_or(false);
@@ -95,75 +123,36 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 			))
 			.http(url.clone())
 			.with_poll_interval(Duration::from_millis(evm_provider.call_interval));
-		let provider_builder = ProviderBuilder::new()
-			.disable_recommended_fillers()
-			.with_cached_nonce_management()
-			.filler(GasFiller)
-			.filler(ChainIdFiller::new(evm_provider.id.into()))
-			.network::<AnyNetwork>();
+		let provider = Arc::new(
+			ProviderBuilder::new()
+				.disable_recommended_fillers()
+				.with_cached_nonce_management()
+				.filler(GasFiller)
+				.filler(ChainIdFiller::new(evm_provider.id.into()))
+				.network::<AnyNetwork>()
+				.wallet(wallet.clone())
+				.on_client(retry_client.clone()),
+		);
+		let client = Arc::new(EthClient::new(
+			provider.clone(),
+			signers.clone(),
+			default_address.clone(),
+			metadata,
+			ProtocolContracts::new(is_native, provider.clone(), evm_provider.clone()),
+			AggregatorContracts::new(
+				provider.clone(),
+				evm_provider.chainlink_usdc_usd_address.clone(),
+				evm_provider.chainlink_usdt_usd_address.clone(),
+				evm_provider.chainlink_dai_usd_address.clone(),
+				evm_provider.chainlink_btc_usd_address.clone(),
+				evm_provider.chainlink_wbtc_usd_address.clone(),
+				evm_provider.chainlink_cbbtc_usd_address.clone(),
+			),
+		));
 
-		let (id, client) = if let Some(key_id) = &signer_config.kms_key_id {
-			let signer = Arc::new(
-				AwsSigner::new(
-					aws_client.as_ref().unwrap().clone(),
-					key_id.clone(),
-					evm_provider.id.into(),
-				)
-				.await
-				.expect(KMS_INITIALIZATION_ERROR),
-			);
-			let provider = Arc::new(
-				provider_builder
-					.wallet(EthereumWallet::from(signer.clone()))
-					.on_client(retry_client),
-			);
-			let client = Arc::new(EthClient::new(
-				provider.clone(),
-				signer.clone(),
-				metadata,
-				ProtocolContracts::new(is_native, provider.clone(), evm_provider.clone()),
-				AggregatorContracts::new(
-					provider.clone(),
-					evm_provider.chainlink_usdc_usd_address.clone(),
-					evm_provider.chainlink_usdt_usd_address.clone(),
-					evm_provider.chainlink_dai_usd_address.clone(),
-					evm_provider.chainlink_btc_usd_address.clone(),
-					evm_provider.chainlink_wbtc_usd_address.clone(),
-					evm_provider.chainlink_cbbtc_usd_address.clone(),
-				),
-			));
-			(evm_provider.id, client)
-		} else {
-			let mut signer = PrivateKeySigner::from_str(
-				&signer_config.private_key.clone().expect(INVALID_PRIVATE_KEY),
-			)
-			.expect(INVALID_PRIVATE_KEY);
-			signer.set_chain_id(Some(evm_provider.id));
-			let signer = Arc::new(signer);
-			let provider = Arc::new(
-				provider_builder
-					.wallet(EthereumWallet::from(signer.clone()))
-					.on_client(retry_client),
-			);
-			let client = Arc::new(EthClient::new(
-				provider.clone(),
-				signer.clone(),
-				metadata,
-				ProtocolContracts::new(is_native, provider.clone(), evm_provider.clone()),
-				AggregatorContracts::new(
-					provider.clone(),
-					evm_provider.chainlink_usdc_usd_address.clone(),
-					evm_provider.chainlink_usdt_usd_address.clone(),
-					evm_provider.chainlink_dai_usd_address.clone(),
-					evm_provider.chainlink_btc_usd_address.clone(),
-					evm_provider.chainlink_wbtc_usd_address.clone(),
-					evm_provider.chainlink_cbbtc_usd_address.clone(),
-				),
-			));
-			(evm_provider.id, client)
-		};
-		clients.insert(id, client);
+		clients.insert(evm_provider.id, client);
 	}
+	// TODO: initialize default address
 
 	let bootstrap_shared_data = BootstrapSharedData::new(&config);
 
@@ -231,7 +220,7 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 		debug_mode,
 	);
 
-	print_relay_targets(&manager_deps);
+	print_relay_targets(&manager_deps).await;
 
 	Ok(spawn_relayer_tasks(
 		task_manager,
@@ -293,7 +282,7 @@ where
 				let report = presubmitter.run().await;
 				let log_msg = format!(
 					"public key presubmitter({}) stopped: {:?}\nRestarting in 12 seconds...",
-					presubmitter.bfc_client.address(),
+					presubmitter.bfc_client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -320,7 +309,7 @@ where
 				let log_msg = format!(
 					"heartbeat sender({}:{}) stopped: {:?}\nRestarting in 12 seconds...",
 					heartbeat_sender.client.get_chain_name(),
-					heartbeat_sender.client.address(),
+					heartbeat_sender.client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -343,7 +332,7 @@ where
 				let log_msg = format!(
 					"oracle price feeder({}:{}) stopped: {:?}\nRestarting in 12 seconds...",
 					oracle_price_feeder.client.get_chain_name(),
-					oracle_price_feeder.client.address(),
+					oracle_price_feeder.client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -368,7 +357,7 @@ where
 					let log_msg = format!(
 						"rollback emitter({}:{}) stopped: {:?}\nRestarting in 12 seconds...",
 						emitter.client.get_chain_name(),
-						emitter.client.address(),
+						emitter.client.address().await,
 						report
 					);
 					log::error!("{log_msg}");
@@ -435,7 +424,7 @@ where
 				let report = roundup_emitter.run().await;
 				let log_msg = format!(
 					"roundup emitter({}) stopped: {:?}\nRestarting immediately...",
-					roundup_emitter.client.address(),
+					roundup_emitter.client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -476,7 +465,7 @@ where
 				let report = inbound.run().await;
 				let log_msg = format!(
 					"bitcoin inbound handler({}) stopped: {:?}\nRestarting immediately...",
-					inbound.bfc_client.address(),
+					inbound.bfc_client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -492,7 +481,7 @@ where
 				let report = outbound.run().await;
 				let log_msg = format!(
 					"bitcoin outbound handler({}) stopped: {:?}\nRestarting immediately...",
-					outbound.bfc_client.address(),
+					outbound.bfc_client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -508,7 +497,7 @@ where
 				let report = psbt_signer.run().await;
 				let log_msg = format!(
 					"bitcoin psbt signer({}) stopped: {:?}\nRestarting immediately...",
-					psbt_signer.client.address(),
+					psbt_signer.client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -524,7 +513,7 @@ where
 				let report = pub_key_submitter.run().await;
 				let log_msg = format!(
 					"bitcoin public key submitter({}) stopped: {:?}\nRestarting immediately...",
-					pub_key_submitter.client.address(),
+					pub_key_submitter.client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -540,7 +529,7 @@ where
 				let report = rollback_verifier.run().await;
 				let log_msg = format!(
 					"bitcoin rollback verifier({}) stopped: {:?}\nRestarting immediately...",
-					rollback_verifier.bfc_client.address(),
+					rollback_verifier.bfc_client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -556,7 +545,7 @@ where
 				let report = block_manager.run().await;
 				let log_msg = format!(
 					"bitcoin block manager({}) stopped: {:?}\nRestarting immediately...",
-					block_manager.bfc_client.address(),
+					block_manager.bfc_client.address().await,
 					report
 				);
 				log::error!("{log_msg}");
@@ -596,7 +585,7 @@ where
 }
 
 /// Log the configured relay targets.
-fn print_relay_targets<F, P>(manager_deps: &ManagerDeps<F, P>)
+async fn print_relay_targets<F, P>(manager_deps: &ManagerDeps<F, P>)
 where
 	F: TxFiller<AnyNetwork> + WalletProvider<AnyNetwork>,
 	P: Provider<AnyNetwork>,
@@ -605,7 +594,7 @@ where
 		target: LOG_TARGET,
 		"-[{}] 👤 Relayer: {:?}",
 		sub_display_format(SUB_LOG_TARGET),
-		manager_deps.bifrost_client.address()
+		manager_deps.bifrost_client.address().await
 	);
 	log::info!(
 		target: LOG_TARGET,

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -153,6 +153,13 @@ pub async fn relay(config: Configuration) -> Result<TaskManager, ServiceError> {
 		// initialize default address to selected account
 		if is_native {
 			client.update_default_address(None).await;
+
+			log::info!(
+				target: LOG_TARGET,
+				"-[{}] 👤 Provided signers: {:?}",
+				sub_display_format(SUB_LOG_TARGET),
+				client.signers()
+			);
 		}
 
 		clients.insert(evm_provider.id, client);


### PR DESCRIPTION
## Description

* `signer_config` fields in config.yaml, now can get multiple elements for smooth relayer account update flow.
* Note: This update is not intended for running multiple signers simultaneously in a single daemon

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
