### PR TITLE
feat: add max_hook_fee option to prevent balance draining

### DIFF
--- a/client/src/eth/traits.rs
+++ b/client/src/eth/traits.rs
@@ -534,6 +534,22 @@ where
 			eyre::eyre!("Gas fee calculation overflow: gas={}, gas_price={}", gas, gas_price),
 		)?;
 
+		// Validate: estimated gas cost must not exceed the configured max hook fee
+		if let Some(max_hook_fee) = self.get_client().metadata.max_hook_fee {
+			if estimated_fee_in_dnc > max_hook_fee {
+				br_primitives::log_and_capture!(
+					warn,
+					&self.get_client().get_chain_name(),
+					SUB_LOG_TARGET,
+					self.get_client().address().await,
+					"⚠️  Estimated hook fee ({} wei) exceeds max_hook_fee limit ({} wei). Skipping hook execution.",
+					estimated_fee_in_dnc,
+					max_hook_fee
+				);
+				return Ok((U256::ZERO, 0));
+			}
+		}
+
 		// Resolve oracle manager from the socket contract
 		let oracle_manager = self.resolve_oracle_manager().await?;
 

--- a/primitives/src/cli.rs
+++ b/primitives/src/cli.rs
@@ -86,6 +86,11 @@ pub struct EVMProvider {
 	/// configured batch size. Default size is set to 1, which means it will be requested on every
 	/// new block. (default: 1)
 	pub get_logs_batch_size: Option<u64>,
+	/// Maximum fee (in destination chain's native currency wei) the relayer will pay to execute
+	/// a single `Hooks.execute()` call. If the estimated gas cost exceeds this value, the hook
+	/// execution is skipped to prevent draining the relayer's native balance.
+	/// Only relevant for chains that have `hooks_address` configured.
+	pub max_hook_fee: Option<u128>,
 	/// Socket contract address
 	pub socket_address: String,
 	/// Authority contract address

--- a/primitives/src/eth.rs
+++ b/primitives/src/eth.rs
@@ -1,6 +1,6 @@
 use alloy::{
 	network::Network,
-	primitives::{Address, ChainId, map::AddressHashMap},
+	primitives::{Address, ChainId, U256, map::AddressHashMap},
 	providers::{
 		Provider, WalletProvider,
 		fillers::{FillProvider, TxFiller},
@@ -108,6 +108,9 @@ pub struct ProviderMetadata {
 	pub is_native: bool,
 	/// The flag whether the chain is relay target.
 	pub is_relay_target: bool,
+	/// Maximum fee in native currency wei the relayer will pay for a single `Hooks.execute()`.
+	/// Hook execution is skipped if the estimated gas cost exceeds this value.
+	pub max_hook_fee: Option<U256>,
 }
 
 impl ProviderMetadata {
@@ -136,6 +139,7 @@ impl ProviderMetadata {
 				false => RelayDirection::Outbound,
 			},
 			is_relay_target: evm_provider.is_relay_target,
+			max_hook_fee: evm_provider.max_hook_fee.map(U256::from),
 		}
 	}
 }


### PR DESCRIPTION
## Description
```
Maximum fee (in destination chain's native currency wei) the relayer will pay to execute
a single `Hooks.execute()` call. If the estimated gas cost exceeds this value, the hook
execution is skipped to prevent draining the relayer's native balance.
Only relevant for chains that have `hooks_address` configured.
```

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
