### PR TITLE
fix: increase rpc size, add gas limitation, set restart interval

### DIFF
--- a/client/src/eth/mod.rs
+++ b/client/src/eth/mod.rs
@@ -435,7 +435,8 @@ where
 
 			let gas = self.estimate_gas(request.clone()).await?;
 			let coefficient: f64 = GasCoefficient::from(self.metadata.is_native).into();
-			let estimated_gas = gas as f64 * coefficient;
+			// max gas limit for a single transaction is 52,000,000 on bifrost network
+			let estimated_gas = (gas as f64 * coefficient).min(52_000_000_f64);
 
 			log::info!(
 				target: &self.get_chain_name(),

--- a/primitives/src/substrate.rs
+++ b/primitives/src/substrate.rs
@@ -54,9 +54,9 @@ use subxt::{
 };
 use url::Url;
 
-/// Maximum WebSocket response body size (64 MB).
+/// Maximum WebSocket response body size (128 MB).
 /// The default jsonrpsee limit is 10 MB, which can be exceeded by large Substrate blocks.
-const MAX_WS_RESPONSE_BODY_SIZE: u32 = 64 * 1024 * 1024;
+const MAX_WS_RESPONSE_BODY_SIZE: u32 = 128 * 1024 * 1024;
 
 #[derive(Debug, Clone)]
 pub enum CustomConfig {}

--- a/relayer/src/service.rs
+++ b/relayer/src/service.rs
@@ -439,11 +439,13 @@ where
 				loop {
 					let report = handler.run().await;
 					let log_msg = format!(
-						"socket onflight handler stopped: {:?}\nRestarting immediately...",
+						"socket onflight handler stopped: {:?}\nRestarting in 12 seconds...",
 						report
 					);
 					log::error!("{log_msg}");
 					sentry::capture_message(&log_msg, sentry::Level::Error);
+
+					tokio::time::sleep(Duration::from_secs(12)).await;
 				}
 			},
 		);


### PR DESCRIPTION
## Description

- increase MAX_WS_RESPONSE_BODY_SIZE to 128MB
- set limitations on estimated gas to 52,000,000
- add 12s restart interval for SocketOnFlightHandler

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
