### PR TITLE
fix: make sure bootstrap state are updated after flush

### DIFF
--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -246,7 +246,14 @@ where
 
 	/// Bootstrap phase 0-2.
 	async fn initial_flushing(&self) -> Result<()> {
-		self.client.flush_stalled_transactions().await?;
+		if let Err(e) = self.client.flush_stalled_transactions().await {
+			br_primitives::log_and_capture_simple!(
+				error,
+				"⚠️ [{}] Failed to flush stalled transactions: {}",
+				self.client.get_chain_name(),
+				e
+			);
+		}
 		self.set_bootstrap_state(BootstrapState::BootstrapRoundUpPhase1).await;
 
 		log::info!(
@@ -263,17 +270,7 @@ where
 		let should_bootstrap = self.is_before_bootstrap_state(BootstrapState::NormalStart).await;
 		if should_bootstrap {
 			self.wait_provider_sync().await.unwrap();
-			match self.initial_flushing().await {
-				Ok(_) => (),
-				Err(e) => {
-					br_primitives::log_and_capture_simple!(
-						error,
-						"⚠️ [{}] Failed to flush stalled transactions: {}",
-						self.client.get_chain_name(),
-						e
-					);
-				},
-			}
+			self.initial_flushing().await.unwrap();
 		}
 	}
 }


### PR DESCRIPTION
## Description

`flush_stalled_transactions()` 호출이 실패해도 `BootstrapState`는 정상 업데이트 되도록 수정

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
