### PR TITLE
harden wait_until_next_time for bad cron and clock skew

### DIFF
--- a/periodic/src/traits.rs
+++ b/periodic/src/traits.rs
@@ -1,6 +1,7 @@
 use cron::Schedule;
 use eyre::Result;
 use std::collections::BTreeMap;
+use std::time::Duration;
 use tokio::time::sleep;
 
 use br_primitives::periodic::PriceResponse;
@@ -15,13 +16,26 @@ pub trait PeriodicWorker {
 
 	/// Wait until it reaches the next schedule.
 	async fn wait_until_next_time(&self) {
-		let sleep_duration =
-			self.schedule().upcoming(chrono::Utc).next().unwrap() - chrono::Utc::now();
+		let now = chrono::Utc::now();
+		let Some(next_fire) = self.schedule().upcoming(chrono::Utc).next() else {
+			log::error!("periodic schedule has no next tick; sleep 60s and retry");
+			sleep(Duration::from_secs(60)).await;
+			return;
+		};
 
-		match sleep_duration.to_std() {
-			Ok(sleep_duration) => sleep(sleep_duration).await,
-			Err(_) => return,
-		}
+		let sleep_chrono = next_fire - now;
+		let sleep_std = match sleep_chrono.to_std() {
+			Ok(d) => d,
+			Err(_) => {
+				log::warn!(
+					"next tick {:?} is not after now {:?}, sleep 1s and retry",
+					next_fire,
+					now
+				);
+				Duration::from_secs(1)
+			},
+		};
+		sleep(sleep_std).await;
 	}
 }
 


### PR DESCRIPTION
hey, looked at the periodic layer and the default wait for every worker had two rough edges.

PeriodicWorker::wait_until_next_time used upcoming().next().unwrap(). if the schedule iterator ever has no next time (weird or broken cron string), the whole relayer process panics. now it logs an error and sleeps 60s so the task keeps running and you can fix config without a restart.

the other path was 	o_std() on the chrono sleep duration: that fails when the next tick is not after Utc::now() (ntp step, clock weirdness, or a race in the last moment before the tick). the old code returned without sleeping, so the loop could spin with almost no backpressure, hammering heartbeats, rpc, etc. now it logs a warn and sleeps 1s so you get a little breathing room and a clue in the logs.

cheers