### PR TITLE
fix: sign psbt through snapshot members

### DIFF
--- a/abi/abi.registration_pool.bifrost.json
+++ b/abi/abi.registration_pool.bifrost.json
@@ -77,6 +77,66 @@
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "user_bfc_address",
+        "type": "address"
+      },
+      {
+        "internalType": "uint32",
+        "name": "pool_round",
+        "type": "uint32"
+      }
+    ],
+    "name": "pending_refund",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint32",
+        "name": "pool_round",
+        "type": "uint32"
+      }
+    ],
+    "name": "pending_refunds",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "who",
+            "type": "address"
+          },
+          {
+            "internalType": "string",
+            "name": "old_refund",
+            "type": "string"
+          },
+          {
+            "internalType": "string",
+            "name": "new_refund",
+            "type": "string"
+          }
+        ],
+        "internalType": "struct BtcRegistrationPool.pending_refund_state[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "uint32",
         "name": "pool_round",
         "type": "uint32"
@@ -217,6 +277,38 @@
   {
     "inputs": [
       {
+        "internalType": "uint32",
+        "name": "pool_round",
+        "type": "uint32"
+      }
+    ],
+    "name": "relay_executives",
+    "outputs": [
+      {
+        "internalType": "address[]",
+        "name": "",
+        "type": "address[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "refund_address",
+        "type": "string"
+      }
+    ],
+    "name": "request_set_refund",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
         "internalType": "string",
         "name": "refund_address",
         "type": "string"
@@ -289,42 +381,6 @@
         "internalType": "string[]",
         "name": "",
         "type": "string[]"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint32",
-        "name": "pool_round",
-        "type": "uint32"
-      }
-    ],
-    "name": "pending_refunds",
-    "outputs": [
-      {
-        "internalType": "struct pending_refund_state[]",
-        "name": "",
-        "type": "tuple[]",
-        "components": [
-          {
-            "internalType": "address",
-            "name": "who",
-            "type": "address"
-          },
-          {
-            "internalType": "string",
-            "name": "old_refund",
-            "type": "string"
-          },
-          {
-            "internalType": "string",
-            "name": "new_refund",
-            "type": "string"
-          }
-        ]
       }
     ],
     "stateMutability": "view",

--- a/periodic/src/psbt_signer.rs
+++ b/periodic/src/psbt_signer.rs
@@ -77,9 +77,17 @@ where
 	}
 
 	/// Verify whether the current relayer is an executive.
+	///
+	/// PSBT signing must only be performed by relay executives of the current round.
+	/// Note that the `relay_executives` precompile holds only the realtime (current) members.
+	/// During vault migration, when the new executive set is being established
+	/// (members replaced, removed, or added), the round *before* migration must be
+	/// used to identify who is authorized to sign — not the incoming round's members.
 	async fn is_relay_executive(&self) -> Result<bool> {
-		let relay_exec = self.client.protocol_contracts.relay_executive.as_ref().unwrap();
-		Ok(relay_exec.is_member(self.client.address().await).call().await?)
+		let round = self.get_current_round().await?;
+		let registration_pool = self.client.protocol_contracts.registration_pool.as_ref().unwrap();
+		let relay_executives = registration_pool.relay_executives(round).call().await?;
+		Ok(relay_executives.contains(&self.client.address().await))
 	}
 
 	/// Build the payload for the unsigned transaction. (`submit_signed_psbt()`)


### PR DESCRIPTION
## Description

Previously, is_relay_executive used the relay_executive precompile which only reflects realtime (current) membership. This is incorrect during vault migration: once the new
executive set is applied, the precompile immediately reflects the new members, excluding executives from the prior round who still hold signing authority over in-flight PSBTs.

This fix switches to querying relay_executives(round) on the RegistrationPool contract, using the current round number as a snapshot anchor. This ensures that the correct set of
authorized signers is used regardless of whether a membership change is in progress.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
