### PR TITLE
fix: update default address and local round on round change

### DIFF
--- a/periodic/src/roundup_emitter.rs
+++ b/periodic/src/roundup_emitter.rs
@@ -84,19 +84,17 @@ where
 
 				let new_relayers = self.fetch_validator_list(latest_round).await?;
 
-				if !self.is_selected_relayer(latest_round - U256::from(1)).await? {
-					continue;
+				if self.is_selected_relayer(latest_round - U256::from(1)).await? {
+					self.request_send_transaction(
+						self.build_transaction(
+							latest_round,
+							new_relayers.clone(),
+							self.client.address().await,
+						)
+						.await?,
+						VSPPhase1Metadata::new(latest_round, new_relayers.clone()),
+					);
 				}
-
-				self.request_send_transaction(
-					self.build_transaction(
-						latest_round,
-						new_relayers.clone(),
-						self.client.address().await,
-					)
-					.await?,
-					VSPPhase1Metadata::new(latest_round, new_relayers.clone()),
-				);
 
 				self.current_round = latest_round;
 				self.client.update_default_address(Some(&new_relayers)).await;


### PR DESCRIPTION
## Description

  - Fixed a bug where a newly joined relayer gets stuck after a round transition and stops functioning (no heartbeats, no
  socket event processing)
  - Only previous-round relayers are responsible for submitting the VSP phase 1 vote, but `current_round` advancement and
  `default_address` update must happen for all relayers regardless

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
