### PR TITLE
fix: install ca-certificates in slim runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,12 @@ RUN cargo build --release
 # 2nd stage: where we run bifrost-relayer binary
 FROM debian:stable-slim
 
+# TLS clients (rustls/native-roots) read the system CA trust store, which the
+# slim image does not ship. Without it: "No CA certificates were loaded from the system".
+RUN apt-get update \
+	&& apt-get install -y --no-install-recommends ca-certificates \
+	&& rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /relayer/target/release/bifrost-relayer /usr/local/bin
 COPY --from=builder /relayer/configs /configs
 


### PR DESCRIPTION
The debian:stable-slim runtime image ships without system CA certificates, so rustls-based TLS clients that read the system trust store fail at runtime with "No CA certificates were loaded from the system". Install the ca-certificates package in the runtime stage.

## Description

Please include a summary of the changes you request.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
