### PR TITLE
minor fixes

### DIFF
--- a/client/src/eth/events.rs
+++ b/client/src/eth/events.rs
@@ -114,7 +114,7 @@ where
 
 		while (stream.next().await).is_some() {
 			let latest_block = self.client.get_block_number().await?;
-			while self.has_new_block(latest_block) {
+			while self.is_batch_ready(latest_block) {
 				self.process_new_block().await?;
 
 				if self.is_balance_sync_enabled {
@@ -180,9 +180,12 @@ where
 		br_metrics::set_block_height(&self.client.get_chain_name(), self.waiting_block);
 	}
 
-	/// Verifies if there are new blocks to process.
+	/// Verifies if the next batch of blocks has fully mined and is ready to process.
+	/// Note: This does not wait for confirmations, only for `get_logs_batch_size` blocks to
+	/// exist, so the `eth_getLogs` batch range never reaches past the chain head. Handlers that
+	/// need confirmation (e.g., SocketRelayHandler) implement their own waiting logic.
 	#[inline]
-	fn has_new_block(&self, latest_block: u64) -> bool {
+	fn is_batch_ready(&self, latest_block: u64) -> bool {
 		if self.waiting_block > latest_block {
 			// difference is greater than 100 blocks
 			// if it suddenly rollbacked to an old block
@@ -197,8 +200,10 @@ where
 			}
 			return false;
 		}
-		// Process immediately without waiting for confirmations
-		self.waiting_block <= latest_block
+		let to = self
+			.waiting_block
+			.saturating_add(self.client.metadata.get_logs_batch_size.saturating_sub(1u64));
+		latest_block >= to
 	}
 
 	/// Bootstrap phase 0-1.

--- a/client/src/eth/mod.rs
+++ b/client/src/eth/mod.rs
@@ -652,7 +652,9 @@ pub fn send_transaction<F, P, N: Network>(
 	this_handle.spawn("send_transaction", None, async move {
 		if let Err(err) = client.fill_gas(&mut request).await {
 			if debug_mode {
-				if err.to_string().contains("revert tx already executed") {
+				let err_string = err.to_string();
+
+				if err_string.contains("revert tx already executed") {
 					return;
 				}
 
@@ -664,7 +666,20 @@ pub fn send_transaction<F, P, N: Network>(
 					err
 				);
 				log::error!(target: &requester, "{msg}");
-				sentry::capture_message(&msg, sentry::Level::Error);
+
+				const SENTRY_IGNORE_PATTERNS: [&str; 4] = [
+					// roundup already executed on external chain through round_control_relay()
+					"latest round",
+					// outbound aggregated relay already executed
+					"_outbound_exec_relay status",
+					// inbound aggregated relay already executed
+					"phase3",
+					// bridge request already committed
+					"revert poll filtered",
+				];
+				if !SENTRY_IGNORE_PATTERNS.iter().any(|pattern| err_string.contains(pattern)) {
+					sentry::capture_message(&msg, sentry::Level::Error);
+				}
 			}
 			return;
 		}

--- a/client/src/eth/traits.rs
+++ b/client/src/eth/traits.rs
@@ -70,13 +70,12 @@ pub trait SocketMessageSizeGuard {
 	async fn fetch_max_socket_message_bytes(&self) -> Result<u32> {
 		Ok(self
 			.sub_client()
-			.storage()
-			.at_latest()
+			.at_current_block()
 			.await?
-			.fetch_or_default(
-				&bifrost_runtime::storage().btc_socket_queue().max_socket_message_bytes(),
-			)
-			.await?)
+			.storage()
+			.fetch(bifrost_runtime::storage().btc_socket_queue().max_socket_message_bytes(), ())
+			.await?
+			.decode()?)
 	}
 
 	/// Checks whether the encoded `SocketMessage` byte size exceeds the configured limit,


### PR DESCRIPTION
## Description

  - Fix eth_getLogs batching on chains with `get_logs_batch_size > 1` silently dropping CCCP events: the event manager advanced past unmined blocks in a batch instead of
  waiting for the full range to exist on-chain, so any Socket/Roundup event landing in the unmined tail was skipped and never re-queried.
  - Suppress noisy Sentry alerts for gas-estimation failures caused by known-benign races (roundup/relay/poll already executed), while still logging them locally in debug mode.
  - Fix subxt storage query syntax for `fetch_max_socket_message_bytes`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
