### PR TITLE
fix: use latest block for gas estimation on all chains

### DIFF
--- a/client/src/eth/mod.rs
+++ b/client/src/eth/mod.rs
@@ -609,13 +609,9 @@ where
 	}
 
 	fn estimate_gas(&self, tx: N::TransactionRequest) -> EthCall<N, U64, u64> {
-		let call = EthCall::gas_estimate(self.inner.weak_client(), tx);
-
-		if self.chain_id() == 56 || self.chain_id() == 97 {
-			call.map_resp(|r| r.to::<u64>())
-		} else {
-			call.block(BlockNumberOrTag::Pending.into()).map_resp(|r| r.to::<u64>())
-		}
+		EthCall::gas_estimate(self.inner.weak_client(), tx)
+			.block(BlockNumberOrTag::Latest.into())
+			.map_resp(|r| r.to::<u64>())
 	}
 
 	async fn send_transaction_internal(


### PR DESCRIPTION
## Description

  - estimate_gas now always requests the latest block when estimating gas, for every chain.
  - Removes the BSC-specific (chain_id 56/97) branch that previously omitted the block tag, since BSC now supports the block-tag parameter on eth_estimateGas.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
