### PR TITLE
feat: enhance RPC client with reconnecting capabilities

### DIFF
--- a/primitives/Cargo.toml
+++ b/primitives/Cargo.toml
@@ -21,8 +21,7 @@ tokio = { workspace = true, features = [
 	"macros",
 ] }
 miniscript = { workspace = true }
-subxt = { workspace = true }
-jsonrpsee = { workspace = true }
+subxt = { workspace = true, features = ["reconnecting-rpc-client"] }
 bitcoincore-rpc = { workspace = true }
 url = { workspace = true }
 sha3 = { workspace = true }

--- a/primitives/src/substrate.rs
+++ b/primitives/src/substrate.rs
@@ -40,11 +40,13 @@ pub use runtime_types::{
 };
 
 use super::constants::errors::INVALID_PROVIDER_URL;
-use jsonrpsee::ws_client::WsClientBuilder;
 use subxt::{
 	OnlineClient,
 	config::{Config, DefaultTransactionExtensions, SubstrateConfig},
-	rpcs::RpcClient,
+	rpcs::{
+		RpcClient,
+		client::{ReconnectingRpcClient, reconnecting_rpc_client::RpcError},
+	},
 };
 use url::Url;
 
@@ -79,12 +81,17 @@ pub async fn initialize_sub_client(mut url: Url) -> OnlineClient<CustomConfig> {
 }
 
 /// Create an `RpcClient` with an increased max WebSocket response body size.
-pub async fn create_rpc_client(url: &str) -> Result<RpcClient, jsonrpsee::core::ClientError> {
-	let ws_client = WsClientBuilder::default()
+///
+/// The underlying transport is a self-reconnecting WebSocket client: if the connection to the
+/// node provider drops, it automatically re-establishes the connection (with exponential
+/// backoff) in the background instead of leaving every subsequent call failing with
+/// "restart required".
+pub async fn create_rpc_client(url: &str) -> Result<RpcClient, RpcError> {
+	let reconnecting_client = ReconnectingRpcClient::builder()
 		.max_response_size(MAX_WS_RESPONSE_BODY_SIZE)
 		.build(url)
 		.await?;
-	Ok(RpcClient::new(ws_client))
+	Ok(RpcClient::new(reconnecting_client))
 }
 
 pub fn get_sub_rpc_url(mut url: Url) -> String {

--- a/relayer/Cargo.toml
+++ b/relayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bifrost-relayer"
-version = "3.0.1"
+version = "3.0.2"
 description = "The core rust implementation for Bifrost relayer"
 authors = { workspace = true }
 homepage = { workspace = true }


### PR DESCRIPTION
## Description

Updated the `create_rpc_client` function to utilize a `ReconnectingRpcClient`, allowing automatic reconnection to the node provider on connection drops. Also updated the `Cargo.toml` for `subxt` to include the new feature. Bumped the relayer version to 3.0.2.

### Reconnect policy
`ExponentialBackoff::from_millis(10).max_delay(Duration::from_secs(60))`
That means delays grow as 10ms → 100ms → 1s → 10s → then capped at 60s.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Something else (simple changes that are not related to existing functionality or others)

# Checklist

- [ ] I have selected the correct base branch.
- [ ] I have performed a self-review of my own code.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have made new test codes regarding to my changes.
- [ ] I have no personal secrets or credentials described on my changes.
- [ ] I have run `cargo-clippy`  and linted my code.
- [ ] My changes generate no new warnings.
- [ ] My changes passed the existing test codes.
- [ ] My changes are able to compile.
